### PR TITLE
Heretic: consolidate wide and 4:3 code into one executable

### DIFF
--- a/src/heretic/ct_chat.c
+++ b/src/heretic/ct_chat.c
@@ -205,7 +205,7 @@ boolean CT_Responder(event_t * ev)
         }
         CT_queueChatChar(sendto);
         chatmodeon = true;
-        I_StartTextInput(25, 10, SCREENWIDTH, 18);
+        I_StartTextInput(25, 10, screenwidth, 18);
         return true;
     }
     else
@@ -378,7 +378,7 @@ void CT_Drawer(void)
                 x += patch->width;
             }
         }
-        V_DrawShadowedPatchRaven(x, 10, W_CacheLumpName(DEH_String("FONTA63"), PU_CACHE)); // [JN] Replaced to FONTA63 ('_')
+        V_DrawShadowedPatchRaven(x, 10, W_CacheLumpName(DEH_String("FONTA59"), PU_CACHE)); // [JN] Replaced to FONTA59 ('_')
         BorderTopRefresh = true;
         UpdateState |= I_MESSAGES;
     }

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -149,9 +149,9 @@ void DrawMessage(void)
     }
 
     if (english_language)
-    MN_DrTextA(player->message, 160 - MN_TextAWidth(player->message) / 2 + ORIGWIDTH_DELTA, 1);
+    MN_DrTextA(player->message, 160 - MN_TextAWidth(player->message) / 2 + wide_delta, 1);
     else
-    MN_DrTextSmallRUS(player->message, 160 - MN_DrTextSmallRUSWidth(player->message) / 2 + ORIGWIDTH_DELTA, 1);
+    MN_DrTextSmallRUS(player->message, 160 - MN_DrTextSmallRUSWidth(player->message) / 2 + wide_delta, 1);
 }
 
 //---------------------------------------------------------------------------
@@ -223,13 +223,13 @@ void D_Display(void)
     {
         if (!netgame)
         {
-            V_DrawShadowedPatchRaven(160 + ORIGWIDTH_DELTA, (viewwindowy >> hires) + 5, 
+            V_DrawShadowedPatchRaven(160 + wide_delta, (viewwindowy >> hires) + 5, 
                                      W_CacheLumpName(DEH_String(english_language ? 
                                                                 "PAUSED" : "RD_PAUSE"), PU_CACHE));
         }
         else
         {
-            V_DrawShadowedPatchRaven(160 + ORIGWIDTH_DELTA, 70, 
+            V_DrawShadowedPatchRaven(160 + wide_delta, 70, 
                                      W_CacheLumpName(DEH_String(english_language ? 
                                                                 "PAUSED" : "RD_PAUSE"), PU_CACHE));
         }
@@ -344,11 +344,12 @@ void D_PageTicker(void)
 
 void D_PageDrawer(void)
 {
-#ifdef WIDESCREEN
-    // [JN] Clean up remainings of the wide screen before
-    // drawing any new RAW screen.
-    V_DrawFilledBox(0, 0, SCREENWIDTH, SCREENHEIGHT, 0);
-#endif
+    if (widescreen)
+    {
+        // [JN] Clean up remainings of the wide screen before
+        // drawing any new RAW screen.
+        V_DrawFilledBox(0, 0, WIDESCREENWIDTH, SCREENHEIGHT, 0);
+    }
 
     V_DrawRawScreen(W_CacheLumpName(pagename, PU_CACHE));
     if (demosequence == 1)

--- a/src/heretic/f_finale.c
+++ b/src/heretic/f_finale.c
@@ -41,6 +41,8 @@ char *finaleflat;
 int FontABaseLump;
 int FontFBaseLump;
 
+extern int screenblocks;
+
 extern boolean automapactive;
 extern boolean viewactive;
 
@@ -181,15 +183,15 @@ void F_TextWrite(void)
     dest = I_VideoBuffer;
     for (y = 0; y < SCREENHEIGHT; y++)
     {
-        for (x = 0; x < SCREENWIDTH / 64; x++)
+        for (x = 0; x < screenwidth / 64; x++)
         {
             memcpy(dest, src + ((y & 63) << 6), 64);
             dest += 64;
         }
-        if (SCREENWIDTH & 63)
+        if (screenwidth & 63)
         {
-            memcpy(dest, src + ((y & 63) << 6), SCREENWIDTH & 63);
-            dest += (SCREENWIDTH & 63);
+            memcpy(dest, src + ((y & 63) << 6), screenwidth & 63);
+            dest += (screenwidth & 63);
         }
     }
 
@@ -226,10 +228,16 @@ void F_TextWrite(void)
 
         w = W_CacheLumpNum((FontABaseLump) + c - 33, PU_CACHE);
 
-        if (cx + SHORT(w->width) > SCREENWIDTH)
+        if (cx + SHORT(w->width) > screenwidth)
             break;
-        V_DrawShadowedPatchRaven(cx + ORIGWIDTH_DELTA, cy, w);
+        V_DrawShadowedPatchRaven(cx + wide_delta, cy, w);
         cx += SHORT(w->width);
+    }
+
+    // [JN] Wide screen: draw black borders in emulated 4:3 mode.
+    if (widescreen && screenblocks == 9)
+    {
+        V_DrawBlackBorders();
     }
 }
 
@@ -256,15 +264,15 @@ void F_TextWriteRUS(void)
     dest = I_VideoBuffer;
     for (y = 0; y < SCREENHEIGHT; y++)
     {
-        for (x = 0; x < SCREENWIDTH / 64; x++)
+        for (x = 0; x < screenwidth / 64; x++)
         {
             memcpy(dest, src + ((y & 63) << 6), 64);
             dest += 64;
         }
-        if (SCREENWIDTH & 63)
+        if (screenwidth & 63)
         {
-            memcpy(dest, src + ((y & 63) << 6), SCREENWIDTH & 63);
-            dest += (SCREENWIDTH & 63);
+            memcpy(dest, src + ((y & 63) << 6), screenwidth & 63);
+            dest += (screenwidth & 63);
         }
     }
 
@@ -299,10 +307,16 @@ void F_TextWriteRUS(void)
 
         w = W_CacheLumpNum((FontFBaseLump) + c - 33, PU_CACHE);
 
-        if (cx + SHORT(w->width) > SCREENWIDTH)
+        if (cx + SHORT(w->width) > screenwidth)
             break;
-        V_DrawShadowedPatchRaven(cx + ORIGWIDTH_DELTA, cy, w);
+        V_DrawShadowedPatchRaven(cx + wide_delta, cy, w);
         cx += SHORT(w->width);
+    }
+
+    // [JN] Wide screen: draw black borders in emulated 4:3 mode.
+    if (widescreen && screenblocks == 9)
+    {
+        V_DrawBlackBorders();
     }
 }
 
@@ -320,13 +334,13 @@ void F_DrawPatchCol(int x, patch_t * patch, int col)
     while (column->topdelta != 0xff)
     {
         source = (byte *) column + 3;
-        dest = desttop + column->topdelta * SCREENWIDTH;
+        dest = desttop + column->topdelta * screenwidth;
         count = column->length;
 
         while (count--)
         {
             *dest = *source++;
-            dest += SCREENWIDTH;
+            dest += screenwidth;
         }
         column = (column_t *) ((byte *) column + column->length + 4);
     }
@@ -405,7 +419,7 @@ void F_DrawUnderwater(void)
             if (!underwawa)
             {
                 underwawa = true;
-                V_DrawFilledBox(0, 0, SCREENWIDTH, SCREENHEIGHT, 0);
+                V_DrawFilledBox(0, 0, screenwidth, SCREENHEIGHT, 0);
                 lumpname = DEH_String(usegamma <= 8 ?
                                       "E2PALFIX" :
                                       "E2PAL");
@@ -467,7 +481,7 @@ void F_BunnyScroll(void)
     p1 = W_CacheLumpName("PFUB2", PU_LEVEL);
     p2 = W_CacheLumpName("PFUB1", PU_LEVEL);
 
-    V_MarkRect(0, 0, SCREENWIDTH, SCREENHEIGHT);
+    V_MarkRect(0, 0, screenwidth, SCREENHEIGHT);
 
     scrolled = 320 - (finalecount - 230) / 2;
     if (scrolled > 320)
@@ -475,7 +489,7 @@ void F_BunnyScroll(void)
     if (scrolled < 0)
         scrolled = 0;
 
-    for (x = 0; x < SCREENWIDTH; x++)
+    for (x = 0; x < screenwidth; x++)
     {
         if (x + scrolled < 320)
             F_DrawPatchCol(x, p1, x + scrolled);
@@ -487,7 +501,7 @@ void F_BunnyScroll(void)
         return;
     if (finalecount < 1180)
     {
-        V_DrawPatch((SCREENWIDTH - 13 * 8) / 2, (SCREENHEIGHT - 8 * 8) / 2, 0,
+        V_DrawPatch((screenwidth - 13 * 8) / 2, (SCREENHEIGHT - 8 * 8) / 2, 0,
                     W_CacheLumpName("END0", PU_CACHE));
         laststage = 0;
         return;
@@ -503,7 +517,7 @@ void F_BunnyScroll(void)
     }
 
     M_snprintf(name, sizeof(name), "END%i", stage);
-    V_DrawPatch((SCREENWIDTH - 13 * 8) / 2, (SCREENHEIGHT - 8 * 8) / 2,
+    V_DrawPatch((screenwidth - 13 * 8) / 2, (SCREENHEIGHT - 8 * 8) / 2,
                 W_CacheLumpName(name, PU_CACHE));
 }
 #endif
@@ -532,7 +546,7 @@ void F_Drawer(void)
         {
             case 1:
                 // [JN] Clean up remainings of the wide screen
-                V_DrawFilledBox(0, 0, SCREENWIDTH, SCREENHEIGHT, 0);
+                V_DrawFilledBox(0, 0, screenwidth, SCREENHEIGHT, 0);
                 if (gamemode == shareware)
                 {
                     V_DrawRawScreen(W_CacheLumpName(english_language ? 
@@ -554,12 +568,12 @@ void F_Drawer(void)
                 break;
             case 3:
                 // [JN] Clean up remainings of the wide screen
-                V_DrawFilledBox(0, 0, SCREENWIDTH, SCREENHEIGHT, 0);
+                V_DrawFilledBox(0, 0, screenwidth, SCREENHEIGHT, 0);
                 F_DemonScroll();
                 break;
             case 4:            // Just show credits screen for extended episodes
             case 5:
-                V_DrawFilledBox(0, 0, SCREENWIDTH, SCREENHEIGHT, 0);
+                V_DrawFilledBox(0, 0, screenwidth, SCREENHEIGHT, 0);
                 if (english_language)
                 V_DrawRawScreen(W_CacheLumpName("CREDIT", PU_CACHE));
                 else

--- a/src/heretic/in_lude.c
+++ b/src/heretic/in_lude.c
@@ -549,8 +549,11 @@ void IN_Drawer(void)
     }
     oldinterstate = interstate;
 
-    // [JN] Remove intermission stats background, fill with black color
-    V_DrawFilledBox(viewwindowx, viewwindowy, scaledviewwidth, viewheight, 0);
+    if (widescreen)
+    {
+        // [JN] Wide screen: clean up wide screen remainings before drawing.
+        V_DrawFilledBox(0, 0, WIDESCREENWIDTH, SCREENHEIGHT, 0);
+    }
 
     switch (interstate)
     {
@@ -572,21 +575,21 @@ void IN_Drawer(void)
         case 1:                // leaving old level
             if (gameepisode < 4)
             {
-                V_DrawPatch(0 + ORIGWIDTH_DELTA, 0, patchINTERPIC);
+                V_DrawPatch(wide_delta, 0, patchINTERPIC);
                 IN_DrawOldLevel();
             }
             break;
         case 2:                // going to the next level
             if (gameepisode < 4)
             {
-                V_DrawPatch(0 + ORIGWIDTH_DELTA, 0, patchINTERPIC);
+                V_DrawPatch(wide_delta, 0, patchINTERPIC);
                 IN_DrawYAH();
             }
             break;
         case 3:                // waiting before going to the next level
             if (gameepisode < 4)
             {
-                V_DrawPatch(0 + ORIGWIDTH_DELTA, 0, patchINTERPIC);
+                V_DrawPatch(wide_delta, 0, patchINTERPIC);
             }
             break;
         default:
@@ -595,6 +598,12 @@ void IN_Drawer(void)
             else
             I_Error("IN_lude: Ошибка последовательности в межмиссионном экране.\n");
             break;
+    }
+
+    // [JN] Wide screen: draw black borders in emulated 4:3 mode.
+    if (widescreen && screenblocks == 9)
+    {
+        V_DrawBlackBorders();
     }
 }
 
@@ -617,15 +626,15 @@ void IN_DrawStatBack(void)
 
     for (y = 0; y < SCREENHEIGHT; y++)
     {
-        for (x = 0; x < SCREENWIDTH / 64; x++)
+        for (x = 0; x < screenwidth / 64; x++)
         {
             memcpy(dest, src + ((y & 63) << 6), 64);
             dest += 64;
         }
-        if (SCREENWIDTH & 63)
+        if (screenwidth & 63)
         {
-            memcpy(dest, src + ((y & 63) << 6), SCREENWIDTH & 63);
-            dest += (SCREENWIDTH & 63);
+            memcpy(dest, src + ((y & 63) << 6), screenwidth & 63);
+            dest += (screenwidth & 63);
         }
     }
 }
@@ -647,30 +656,30 @@ void IN_DrawOldLevel(void)
     if (english_language)
     {
         x = 160 - MN_TextBWidth(LevelNames[(gameepisode - 1) * 9 + prevmap - 1] + 7) / 2;
-        IN_DrTextB(LevelNames[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + ORIGWIDTH_DELTA, 3);
+        IN_DrTextB(LevelNames[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + wide_delta, 3);
 
         x = 160 - MN_TextAWidth(DEH_String("FINISHED")) / 2;
-        MN_DrTextA(DEH_String("FINISHED"), x + ORIGWIDTH_DELTA, 25);
+        MN_DrTextA(DEH_String("FINISHED"), x + wide_delta, 25);
     }
     else
     {
         x = 160 - MN_DrTextBigRUSWidth(LevelNames_Rus[(gameepisode - 1) * 9 + prevmap - 1] + 7) / 2;
-        IN_DrTextBigRUS(LevelNames_Rus[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + ORIGWIDTH_DELTA, 3);
+        IN_DrTextBigRUS(LevelNames_Rus[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + wide_delta, 3);
 
         x = 160 - MN_DrTextSmallRUSWidth(DEH_String("EHJDTYM PFDTHITY")) / 2;         // УРОВЕНЬ ЗАВЕРШЕН
-        MN_DrTextSmallRUS(DEH_String("EHJDTYM PFDTHITY"), x + ORIGWIDTH_DELTA, 25); // УРОВЕНЬ ЗАВЕРШЕН
+        MN_DrTextSmallRUS(DEH_String("EHJDTYM PFDTHITY"), x + wide_delta, 25); // УРОВЕНЬ ЗАВЕРШЕН
     }
 
     if (prevmap == 9)
     {
         for (i = 0; i < gamemap - 1; i++)
         {
-            V_DrawPatch(YAHspot[gameepisode - 1][i].x + ORIGWIDTH_DELTA,
+            V_DrawPatch(YAHspot[gameepisode - 1][i].x + wide_delta,
                         YAHspot[gameepisode - 1][i].y, patchBEENTHERE);
         }
         if (!(intertime & 16))
         {
-            V_DrawPatch(YAHspot[gameepisode - 1][8].x + ORIGWIDTH_DELTA,
+            V_DrawPatch(YAHspot[gameepisode - 1][8].x + wide_delta,
                         YAHspot[gameepisode - 1][8].y, patchBEENTHERE);
         }
     }
@@ -678,17 +687,17 @@ void IN_DrawOldLevel(void)
     {
         for (i = 0; i < prevmap - 1; i++)
         {
-            V_DrawPatch(YAHspot[gameepisode - 1][i].x + ORIGWIDTH_DELTA,
+            V_DrawPatch(YAHspot[gameepisode - 1][i].x + wide_delta,
                         YAHspot[gameepisode - 1][i].y, patchBEENTHERE);
         }
         if (players[consoleplayer].didsecret)
         {
-            V_DrawPatch(YAHspot[gameepisode - 1][8].x + ORIGWIDTH_DELTA,
+            V_DrawPatch(YAHspot[gameepisode - 1][8].x + wide_delta,
                         YAHspot[gameepisode - 1][8].y, patchBEENTHERE);
         }
         if (!(intertime & 16))
         {
-            V_DrawPatch(YAHspot[gameepisode - 1][prevmap - 1].x + ORIGWIDTH_DELTA,
+            V_DrawPatch(YAHspot[gameepisode - 1][prevmap - 1].x + wide_delta,
                         YAHspot[gameepisode - 1][prevmap - 1].y,
                         patchBEENTHERE);
         }
@@ -709,18 +718,18 @@ void IN_DrawYAH(void)
     if (english_language)
     {
         x = 160 - MN_TextAWidth(DEH_String("NOW ENTERING:")) / 2;
-        MN_DrTextA(DEH_String("NOW ENTERING:"), x + ORIGWIDTH_DELTA, 10);
+        MN_DrTextA(DEH_String("NOW ENTERING:"), x + wide_delta, 10);
 
         x = 160 - MN_TextBWidth(LevelNames[(gameepisode - 1) * 9 + gamemap - 1] + 7) / 2;
-        IN_DrTextB(LevelNames[(gameepisode - 1) * 9 + gamemap - 1] + 7, x + ORIGWIDTH_DELTA, 20);
+        IN_DrTextB(LevelNames[(gameepisode - 1) * 9 + gamemap - 1] + 7, x + wide_delta, 20);
     }
     else
     {
         x = 160 - MN_DrTextSmallRUSWidth(DEH_String("PFUHE;FTNCZ EHJDTYM")) / 2;            // ЗАГРУЖАЕТСЯ УРОВЕНЬ
-        MN_DrTextSmallRUS(DEH_String("PFUHE;FTNCZ EHJDTYM"), x + ORIGWIDTH_DELTA, 10);    // ЗАГРУЖАЕТСЯ УРОВЕНЬ
+        MN_DrTextSmallRUS(DEH_String("PFUHE;FTNCZ EHJDTYM"), x + wide_delta, 10);    // ЗАГРУЖАЕТСЯ УРОВЕНЬ
 
         x = 160 - MN_DrTextBigRUSWidth(LevelNames_Rus[(gameepisode - 1) * 9 + gamemap - 1] + 7) / 2;
-        IN_DrTextBigRUS(LevelNames_Rus[(gameepisode - 1) * 9 + gamemap - 1] + 7, x + ORIGWIDTH_DELTA, 20);
+        IN_DrTextBigRUS(LevelNames_Rus[(gameepisode - 1) * 9 + gamemap - 1] + 7, x + wide_delta, 20);
     }
 
     if (prevmap == 9)
@@ -729,17 +738,17 @@ void IN_DrawYAH(void)
     }
     for (i = 0; i < prevmap; i++)
     {
-        V_DrawShadowedPatchRaven(YAHspot[gameepisode - 1][i].x + ORIGWIDTH_DELTA,
+        V_DrawShadowedPatchRaven(YAHspot[gameepisode - 1][i].x + wide_delta,
                     YAHspot[gameepisode - 1][i].y, patchBEENTHERE);
     }
     if (players[consoleplayer].didsecret)
     {
-        V_DrawShadowedPatchRaven(YAHspot[gameepisode - 1][8].x + ORIGWIDTH_DELTA,
+        V_DrawShadowedPatchRaven(YAHspot[gameepisode - 1][8].x + wide_delta,
                     YAHspot[gameepisode - 1][8].y, patchBEENTHERE);
     }
     if (!(intertime & 16) || interstate == 3)
     {                           // draw the destination 'X'
-        V_DrawShadowedPatchRaven(YAHspot[gameepisode - 1][gamemap - 1].x + ORIGWIDTH_DELTA,
+        V_DrawShadowedPatchRaven(YAHspot[gameepisode - 1][gamemap - 1].x + wide_delta,
                     YAHspot[gameepisode - 1][gamemap - 1].y, patchGOINGTHERE);
     }
 }
@@ -766,27 +775,27 @@ void IN_DrawSingleStats(void)
 
     if (english_language)
     {
-        IN_DrTextB(DEH_String("KILLS"), 50 + ORIGWIDTH_DELTA, classic_stats ? 65 : 44);
-        IN_DrTextB(DEH_String("ITEMS"), 50 + ORIGWIDTH_DELTA, classic_stats ? 90 : 66);
-        IN_DrTextB(DEH_String("SECRETS"), 50 + ORIGWIDTH_DELTA, classic_stats ? 115 : 88);
+        IN_DrTextB(DEH_String("KILLS"), 50 + wide_delta, classic_stats ? 65 : 44);
+        IN_DrTextB(DEH_String("ITEMS"), 50 + wide_delta, classic_stats ? 90 : 66);
+        IN_DrTextB(DEH_String("SECRETS"), 50 + wide_delta, classic_stats ? 115 : 88);
 
         x = 160 - MN_TextBWidth(LevelNames[(gameepisode - 1) * 9 + prevmap - 1] + 7) / 2;
-        IN_DrTextB(LevelNames[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + ORIGWIDTH_DELTA, 3);
+        IN_DrTextB(LevelNames[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + wide_delta, 3);
 
         x = 160 - MN_TextAWidth(DEH_String("FINISHED")) / 2;
-        MN_DrTextA(DEH_String("FINISHED"), x + ORIGWIDTH_DELTA, 25);
+        MN_DrTextA(DEH_String("FINISHED"), x + wide_delta, 25);
     }
     else
     {
-        IN_DrTextBigRUS(DEH_String("DHFUB"), 50 + ORIGWIDTH_DELTA, classic_stats ? 65 : 44);    // ВРАГИ
-        IN_DrTextBigRUS(DEH_String("GHTLVTNS"), 50 + ORIGWIDTH_DELTA, classic_stats ? 90 : 66); // ПРЕДМЕТЫ
-        IN_DrTextBigRUS(DEH_String("NFQYBRB"), 50 + ORIGWIDTH_DELTA, classic_stats ? 115 : 88); // ТАЙНИКИ
+        IN_DrTextBigRUS(DEH_String("DHFUB"), 50 + wide_delta, classic_stats ? 65 : 44);    // ВРАГИ
+        IN_DrTextBigRUS(DEH_String("GHTLVTNS"), 50 + wide_delta, classic_stats ? 90 : 66); // ПРЕДМЕТЫ
+        IN_DrTextBigRUS(DEH_String("NFQYBRB"), 50 + wide_delta, classic_stats ? 115 : 88); // ТАЙНИКИ
 
         x = 160 - MN_DrTextBigRUSWidth(LevelNames_Rus[(gameepisode - 1) * 9 + prevmap - 1] + 7) / 2;
-        IN_DrTextBigRUS(LevelNames_Rus[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + ORIGWIDTH_DELTA, 3);
+        IN_DrTextBigRUS(LevelNames_Rus[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + wide_delta, 3);
 
         x = 160 - MN_DrTextSmallRUSWidth(DEH_String("EHJDTYM PFDTHITY")) / 2;         // УРОВЕНЬ ЗАВЕРШЕН
-        MN_DrTextSmallRUS(DEH_String("EHJDTYM PFDTHITY"), x + ORIGWIDTH_DELTA, 25); // УРОВЕНЬ ЗАВЕРШЕН
+        MN_DrTextSmallRUS(DEH_String("EHJDTYM PFDTHITY"), x + wide_delta, 25); // УРОВЕНЬ ЗАВЕРШЕН
     }
 
     if (intertime < 30)
@@ -800,9 +809,9 @@ void IN_DrawSingleStats(void)
         sounds++;
     }
 
-    IN_DrawNumber(players[consoleplayer].killcount, 200 + ORIGWIDTH_DELTA, classic_stats ? 65 : 44, 3);
-    V_DrawShadowedPatch(237 + ORIGWIDTH_DELTA, classic_stats ? 65 : 44, FontBSlash);
-    IN_DrawNumber(totalkills, 248 + ORIGWIDTH_DELTA, classic_stats ? 65 : 44, 3);
+    IN_DrawNumber(players[consoleplayer].killcount, 200 + wide_delta, classic_stats ? 65 : 44, 3);
+    V_DrawShadowedPatch(237 + wide_delta, classic_stats ? 65 : 44, FontBSlash);
+    IN_DrawNumber(totalkills, 248 + wide_delta, classic_stats ? 65 : 44, 3);
 
     if (intertime < 60)
     {
@@ -814,9 +823,9 @@ void IN_DrawSingleStats(void)
         sounds++;
     }
 
-    IN_DrawNumber(players[consoleplayer].itemcount, 200 + ORIGWIDTH_DELTA, classic_stats ? 90 : 66, 3);
-    V_DrawShadowedPatch(237 + ORIGWIDTH_DELTA, classic_stats ? 90 : 66, FontBSlash);
-    IN_DrawNumber(totalitems, 248 + ORIGWIDTH_DELTA, classic_stats ? 90 : 66, 3);
+    IN_DrawNumber(players[consoleplayer].itemcount, 200 + wide_delta, classic_stats ? 90 : 66, 3);
+    V_DrawShadowedPatch(237 + wide_delta, classic_stats ? 90 : 66, FontBSlash);
+    IN_DrawNumber(totalitems, 248 + wide_delta, classic_stats ? 90 : 66, 3);
 
     if (intertime < 90)
     {
@@ -828,9 +837,9 @@ void IN_DrawSingleStats(void)
         sounds++;
     }
 
-    IN_DrawNumber(players[consoleplayer].secretcount, 200 + ORIGWIDTH_DELTA, classic_stats ? 115 : 88, 3);
-    V_DrawShadowedPatch(237 + ORIGWIDTH_DELTA, classic_stats ? 115 : 88, FontBSlash);
-    IN_DrawNumber(totalsecret, 248 + ORIGWIDTH_DELTA, classic_stats ? 115 : 88, 3);
+    IN_DrawNumber(players[consoleplayer].secretcount, 200 + wide_delta, classic_stats ? 115 : 88, 3);
+    V_DrawShadowedPatch(237 + wide_delta, classic_stats ? 115 : 88, FontBSlash);
+    IN_DrawNumber(totalsecret, 248 + wide_delta, classic_stats ? 115 : 88, 3);
 
     if (intertime < 150)
     {
@@ -845,19 +854,19 @@ void IN_DrawSingleStats(void)
     // [JN] Draw level time and total time even for 4 and 5 episodes!
     if (english_language)
     {
-        IN_DrTextB(DEH_String("TIME"), 50 + ORIGWIDTH_DELTA, classic_stats ? 145 : 114);
-        IN_DrawTime(192 + ORIGWIDTH_DELTA, classic_stats ? 145 : 114, hours, minutes, seconds);
+        IN_DrTextB(DEH_String("TIME"), 50 + wide_delta, classic_stats ? 145 : 114);
+        IN_DrawTime(192 + wide_delta, classic_stats ? 145 : 114, hours, minutes, seconds);
 
-        IN_DrTextB(DEH_String("TOTAL"), 50 + ORIGWIDTH_DELTA, classic_stats ? 165 : 134);
-        IN_DrawTime(192 + ORIGWIDTH_DELTA, classic_stats ? 165 : 134, ttime/3600, (ttime%3600)/60, ttime%60);
+        IN_DrTextB(DEH_String("TOTAL"), 50 + wide_delta, classic_stats ? 165 : 134);
+        IN_DrawTime(192 + wide_delta, classic_stats ? 165 : 134, ttime/3600, (ttime%3600)/60, ttime%60);
     }
     else
     {
-        IN_DrTextBigRUS(DEH_String("DHTVZ"), 50 + ORIGWIDTH_DELTA, classic_stats ? 145 : 114);   // ВРЕМЯ
-        IN_DrawTime(192 + ORIGWIDTH_DELTA, classic_stats ? 145 : 114, hours, minutes, seconds);
+        IN_DrTextBigRUS(DEH_String("DHTVZ"), 50 + wide_delta, classic_stats ? 145 : 114);   // ВРЕМЯ
+        IN_DrawTime(192 + wide_delta, classic_stats ? 145 : 114, hours, minutes, seconds);
 
-        IN_DrTextBigRUS(DEH_String("J,OTT DHTVZ"), 50 + ORIGWIDTH_DELTA, classic_stats ? 165 : 134); // ОБЩЕЕ ВРЕМЯ
-        IN_DrawTime(192 + ORIGWIDTH_DELTA, classic_stats ? 165 : 134, ttime/3600, (ttime%3600)/60, ttime%60);
+        IN_DrTextBigRUS(DEH_String("J,OTT DHTVZ"), 50 + wide_delta, classic_stats ? 165 : 134); // ОБЩЕЕ ВРЕМЯ
+        IN_DrawTime(192 + wide_delta, classic_stats ? 165 : 134, ttime/3600, (ttime%3600)/60, ttime%60);
     }
 
     // [JN] Do not display "Now entering" after finishing ExM8
@@ -866,18 +875,18 @@ void IN_DrawSingleStats(void)
         if (english_language)
         {
             x = 160 - MN_TextAWidth(DEH_String("NOW ENTERING:")) / 2;
-            MN_DrTextA(DEH_String("NOW ENTERING:"), x + ORIGWIDTH_DELTA, 160);
+            MN_DrTextA(DEH_String("NOW ENTERING:"), x + wide_delta, 160);
 
             x = 160 - MN_TextBWidth(LevelNames[(gameepisode - 1) * 9 + gamemap - 1] + 7) / 2;
-            IN_DrTextB(LevelNames[(gameepisode - 1) * 9 + gamemap - 1] + 7, x + ORIGWIDTH_DELTA, 170);
+            IN_DrTextB(LevelNames[(gameepisode - 1) * 9 + gamemap - 1] + 7, x + wide_delta, 170);
         }
         else
         {
             x = 160 - MN_DrTextSmallRUSWidth(DEH_String("PFUHE;FTNCZ EHJDTYM")) / 2;             // ЗАГРУЖАЕТСЯ УРОВЕНЬ
-            MN_DrTextSmallRUS(DEH_String("PFUHE;FTNCZ EHJDTYM"), x + ORIGWIDTH_DELTA, 160);    // ЗАГРУЖАЕТСЯ УРОВЕНЬ
+            MN_DrTextSmallRUS(DEH_String("PFUHE;FTNCZ EHJDTYM"), x + wide_delta, 160);    // ЗАГРУЖАЕТСЯ УРОВЕНЬ
 
             x = 160 - MN_DrTextBigRUSWidth(LevelNames_Rus[(gameepisode - 1) * 9 + gamemap - 1] + 7) / 2;
-            IN_DrTextBigRUS(LevelNames_Rus[(gameepisode - 1) * 9 + gamemap - 1] + 7, x + ORIGWIDTH_DELTA, 170);
+            IN_DrTextBigRUS(LevelNames_Rus[(gameepisode - 1) * 9 + gamemap - 1] + 7, x + wide_delta, 170);
         }
         skipintermission = false;
     }
@@ -907,32 +916,32 @@ void IN_DrawCoopStats(void)
 
     if (english_language)
     {
-        IN_DrTextB(DEH_String("KILLS"), 95 + ORIGWIDTH_DELTA, 35);
-        IN_DrTextB(DEH_String("BONUS"), 155 + ORIGWIDTH_DELTA, 35);
-        IN_DrTextB(DEH_String("SECRET"), 232 + ORIGWIDTH_DELTA, 35);
+        IN_DrTextB(DEH_String("KILLS"), 95 + wide_delta, 35);
+        IN_DrTextB(DEH_String("BONUS"), 155 + wide_delta, 35);
+        IN_DrTextB(DEH_String("SECRET"), 232 + wide_delta, 35);
     }
     else
     {
-        IN_DrTextB(DEH_String("DHFUB"), 81 + ORIGWIDTH_DELTA, 35);    // ВРАГИ (95, 35)
-        IN_DrTextB(DEH_String(",JYECS"), 150 + ORIGWIDTH_DELTA, 35);  // БОНУСЫ (155, 35)
-        IN_DrTextB(DEH_String("NFQYBRB"), 232 + ORIGWIDTH_DELTA, 35); // ТАЙНИКИ (232, 35)
+        IN_DrTextB(DEH_String("DHFUB"), 81 + wide_delta, 35);    // ВРАГИ (95, 35)
+        IN_DrTextB(DEH_String(",JYECS"), 150 + wide_delta, 35);  // БОНУСЫ (155, 35)
+        IN_DrTextB(DEH_String("NFQYBRB"), 232 + wide_delta, 35); // ТАЙНИКИ (232, 35)
     }
 
     if (english_language)
     {
         x = 160 - MN_TextBWidth(LevelNames[(gameepisode - 1) * 9 + prevmap - 1] + 7) / 2;
-        IN_DrTextB(LevelNames[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + ORIGWIDTH_DELTA, 3);
+        IN_DrTextB(LevelNames[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + wide_delta, 3);
 
         x = 160 - MN_TextAWidth(DEH_String("FINISHED")) / 2;
-        MN_DrTextA(DEH_String("FINISHED"), x + ORIGWIDTH_DELTA, 25);
+        MN_DrTextA(DEH_String("FINISHED"), x + wide_delta, 25);
     }
     else
     {
         x = 160 - MN_DrTextBigRUSWidth(LevelNames_Rus[(gameepisode - 1) * 9 + prevmap - 1] + 7) / 2;
-        IN_DrTextBigRUS(LevelNames_Rus[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + ORIGWIDTH_DELTA, 3);
+        IN_DrTextBigRUS(LevelNames_Rus[(gameepisode - 1) * 9 + prevmap - 1] + 7, x + wide_delta, 3);
 
         x = 160 - MN_DrTextSmallRUSWidth(DEH_String("EHJDTYM PFDTHITY")) / 2;            // УРОВЕНЬ ЗАВЕРШЕН
-        MN_DrTextSmallRUS(DEH_String("EHJDTYM PFDTHITY"), x + ORIGWIDTH_DELTA, 25);    // УРОВЕНЬ ЗАВЕРШЕН
+        MN_DrTextSmallRUS(DEH_String("EHJDTYM PFDTHITY"), x + wide_delta, 25);    // УРОВЕНЬ ЗАВЕРШЕН
     }
 
     ypos = 50;
@@ -940,7 +949,7 @@ void IN_DrawCoopStats(void)
     {
         if (playeringame[i])
         {
-            V_DrawShadowedPatch(25 + ORIGWIDTH_DELTA, ypos,
+            V_DrawShadowedPatch(25 + wide_delta, ypos,
                                 W_CacheLumpNum(patchFaceOkayBase + i,
                                                PU_CACHE));
             if (intertime < 40)
@@ -957,23 +966,23 @@ void IN_DrawCoopStats(void)
 
             if (english_language)
             {
-                IN_DrawNumber(killPercent[i], 85 + ORIGWIDTH_DELTA, ypos + 10, 3);
-                V_DrawShadowedPatch(121 + ORIGWIDTH_DELTA, ypos + 10, FontBPercent);
-                IN_DrawNumber(bonusPercent[i], 160 + ORIGWIDTH_DELTA, ypos + 10, 3);
-                V_DrawShadowedPatch(196 + ORIGWIDTH_DELTA, ypos + 10, FontBPercent);
-                IN_DrawNumber(secretPercent[i], 237 + ORIGWIDTH_DELTA, ypos + 10, 3);
-                V_DrawShadowedPatch(273 + ORIGWIDTH_DELTA, ypos + 10, FontBPercent);
+                IN_DrawNumber(killPercent[i], 85 + wide_delta, ypos + 10, 3);
+                V_DrawShadowedPatch(121 + wide_delta, ypos + 10, FontBPercent);
+                IN_DrawNumber(bonusPercent[i], 160 + wide_delta, ypos + 10, 3);
+                V_DrawShadowedPatch(196 + wide_delta, ypos + 10, FontBPercent);
+                IN_DrawNumber(secretPercent[i], 237 + wide_delta, ypos + 10, 3);
+                V_DrawShadowedPatch(273 + wide_delta, ypos + 10, FontBPercent);
             }
             else
             {
                 // [JN] Координаты скорректированы в 
                 // соответствии с длинной русских слов.
-                IN_DrawNumber(killPercent[i], 84 + ORIGWIDTH_DELTA, ypos + 10, 3);
-                V_DrawShadowedPatch(120 + ORIGWIDTH_DELTA, ypos + 10, FontBPercent);
-                IN_DrawNumber(bonusPercent[i], 160 + ORIGWIDTH_DELTA, ypos + 10, 3);
-                V_DrawShadowedPatch(196 + ORIGWIDTH_DELTA, ypos + 10, FontBPercent);
-                IN_DrawNumber(secretPercent[i], 247 + ORIGWIDTH_DELTA, ypos + 10, 3);
-                V_DrawShadowedPatch(283 + ORIGWIDTH_DELTA, ypos + 10, FontBPercent);
+                IN_DrawNumber(killPercent[i], 84 + wide_delta, ypos + 10, 3);
+                V_DrawShadowedPatch(120 + wide_delta, ypos + 10, FontBPercent);
+                IN_DrawNumber(bonusPercent[i], 160 + wide_delta, ypos + 10, 3);
+                V_DrawShadowedPatch(196 + wide_delta, ypos + 10, FontBPercent);
+                IN_DrawNumber(secretPercent[i], 247 + wide_delta, ypos + 10, 3);
+                V_DrawShadowedPatch(283 + wide_delta, ypos + 10, FontBPercent);
             }
 
             ypos += 37;
@@ -1002,21 +1011,21 @@ void IN_DrawDMStats(void)
 
     if (english_language)
     {
-        IN_DrTextB(DEH_String("TOTAL"), 265 + ORIGWIDTH_DELTA, 30);
-        MN_DrTextA(DEH_String("VICTIMS"), 140 + ORIGWIDTH_DELTA, 8);
+        IN_DrTextB(DEH_String("TOTAL"), 265 + wide_delta, 30);
+        MN_DrTextA(DEH_String("VICTIMS"), 140 + wide_delta, 8);
     }
     else
     {
-        IN_DrTextBigRUS(DEH_String("BNJU"), 265 + ORIGWIDTH_DELTA, 30);  // ИТОГ
-        MN_DrTextSmallRUS(DEH_String(";THNDS"), 140 + ORIGWIDTH_DELTA, 8); // ЖЕРТВЫ
+        IN_DrTextBigRUS(DEH_String("BNJU"), 265 + wide_delta, 30);  // ИТОГ
+        MN_DrTextSmallRUS(DEH_String(";THNDS"), 140 + wide_delta, 8); // ЖЕРТВЫ
     }
 
     for (i = 0; i < 7; i++)
     {
         if (english_language)
-        MN_DrTextA(DEH_String(KillersText[i]), 10 + ORIGWIDTH_DELTA, 80 + 9 * i);
+        MN_DrTextA(DEH_String(KillersText[i]), 10 + wide_delta, 80 + 9 * i);
         else
-        MN_DrTextSmallRUS(DEH_String(KillersText_Rus[i]), 10 + ORIGWIDTH_DELTA, 80 + 9 * i);
+        MN_DrTextSmallRUS(DEH_String(KillersText_Rus[i]), 10 + wide_delta, 80 + 9 * i);
     }
     if (intertime < 20)
     {
@@ -1024,13 +1033,13 @@ void IN_DrawDMStats(void)
         {
             if (playeringame[i])
             {
-                V_DrawShadowedPatch(40 + ORIGWIDTH_DELTA,
+                V_DrawShadowedPatch(40 + wide_delta,
                                     ((ypos << FRACBITS) +
                                      dSlideY[i] * intertime) >> FRACBITS,
                                     W_CacheLumpNum(patchFaceOkayBase + i,
                                                    PU_CACHE));
                 V_DrawShadowedPatch((((xpos << FRACBITS) + 
-                                     dSlideX[i] * intertime) >> FRACBITS) + ORIGWIDTH_DELTA, 18,
+                                     dSlideX[i] * intertime) >> FRACBITS) + wide_delta, 18,
                                     W_CacheLumpNum(patchFaceDeadBase + i,
                                                    PU_CACHE));
             }
@@ -1054,19 +1063,19 @@ void IN_DrawDMStats(void)
         {
             if (intertime < 100 || i == consoleplayer)
             {
-                V_DrawShadowedPatch(40 + ORIGWIDTH_DELTA, ypos,
+                V_DrawShadowedPatch(40 + wide_delta, ypos,
                                     W_CacheLumpNum(patchFaceOkayBase + i,
                                                    PU_CACHE));
-                V_DrawShadowedPatch(xpos + ORIGWIDTH_DELTA, 18,
+                V_DrawShadowedPatch(xpos + wide_delta, 18,
                                     W_CacheLumpNum(patchFaceDeadBase + i,
                                                    PU_CACHE));
             }
             else
             {
-                V_DrawTLPatch(40 + ORIGWIDTH_DELTA, ypos,
+                V_DrawTLPatch(40 + wide_delta, ypos,
                               W_CacheLumpNum(patchFaceOkayBase + i,
                                              PU_CACHE));
-                V_DrawTLPatch(xpos + ORIGWIDTH_DELTA, 18,
+                V_DrawTLPatch(xpos + wide_delta, 18,
                               W_CacheLumpNum(patchFaceDeadBase + i,
                                              PU_CACHE));
             }
@@ -1075,7 +1084,7 @@ void IN_DrawDMStats(void)
             {
                 if (playeringame[j])
                 {
-                    IN_DrawNumber(players[i].frags[j], kpos + ORIGWIDTH_DELTA, ypos + 10, 3);
+                    IN_DrawNumber(players[i].frags[j], kpos + wide_delta, ypos + 10, 3);
                     kpos += 43;
                 }
             }
@@ -1083,12 +1092,12 @@ void IN_DrawDMStats(void)
             {
                 if (!(intertime & 16))
                 {
-                    IN_DrawNumber(totalFrags[i], 263 + ORIGWIDTH_DELTA, ypos + 10, 3);
+                    IN_DrawNumber(totalFrags[i], 263 + wide_delta, ypos + 10, 3);
                 }
             }
             else
             {
-                IN_DrawNumber(totalFrags[i], 263 + ORIGWIDTH_DELTA, ypos + 10, 3);
+                IN_DrawNumber(totalFrags[i], 263 + wide_delta, ypos + 10, 3);
             }
             ypos += 36;
             xpos += 43;

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -137,8 +137,8 @@ void MN_LoadSlotText(void);
 
 // Rendering
 static void DrawRenderingMenu(void);
+static boolean M_RD_Change_Widescreen(int option);
 static boolean M_RD_Change_VSync(int option);
-static boolean M_RD_AspectRatio(int option);
 static boolean M_RD_Uncapped(int option);
 static boolean M_RD_FPScounter(int option);
 static boolean M_RD_Smoothing(int option);
@@ -265,7 +265,7 @@ static MenuItem_t MainItems_Rus[] = {
 };
 
 static Menu_t MainMenu = {
-    110 + ORIGWIDTH_DELTA, 56,
+    110, 56,
     DrawMainMenu,
     5, MainItems,
     0,
@@ -273,7 +273,7 @@ static Menu_t MainMenu = {
 };
 
 static Menu_t MainMenu_Rus = {
-    103 + ORIGWIDTH_DELTA, 56,
+    103, 56,
     DrawMainMenu,
     5, MainItems_Rus,
     0,
@@ -297,7 +297,7 @@ static MenuItem_t EpisodeItems_Rus[] = {
 };
 
 static Menu_t EpisodeMenu = {
-    80 + ORIGWIDTH_DELTA, 50,
+    80, 50,
     DrawEpisodeMenu,
     3, EpisodeItems,
     0,
@@ -305,7 +305,7 @@ static Menu_t EpisodeMenu = {
 };
 
 static Menu_t EpisodeMenu_Rus = {
-    55 + ORIGWIDTH_DELTA, 50,
+    55, 50,
     DrawEpisodeMenu,
     3, EpisodeItems_Rus,
     0,
@@ -323,7 +323,7 @@ static MenuItem_t FilesItems_Rus[] = {
 };
 
 static Menu_t FilesMenu = {
-    110 + ORIGWIDTH_DELTA, 60,
+    110, 60,
     DrawFilesMenu,
     2, FilesItems,
     0,
@@ -331,7 +331,7 @@ static Menu_t FilesMenu = {
 };
 
 static Menu_t FilesMenu_Rus = {
-    90 + ORIGWIDTH_DELTA, 60,
+    90, 60,
     DrawFilesMenu,
     2, FilesItems_Rus,
     0,
@@ -348,7 +348,7 @@ static MenuItem_t LoadItems[] = {
 };
 
 static Menu_t LoadMenu = {
-    70 + ORIGWIDTH_DELTA, 30,
+    70, 30,
     DrawLoadMenu,
     6, LoadItems,
     0,
@@ -356,7 +356,7 @@ static Menu_t LoadMenu = {
 };
 
 static Menu_t LoadMenu_Rus = {
-    70 + ORIGWIDTH_DELTA, 30,
+    70, 30,
     DrawLoadMenu,
     6, LoadItems,
     0,
@@ -373,7 +373,7 @@ static MenuItem_t SaveItems[] = {
 };
 
 static Menu_t SaveMenu = {
-    70 + ORIGWIDTH_DELTA, 30,
+    70, 30,
     DrawSaveMenu,
     6, SaveItems,
     0,
@@ -381,7 +381,7 @@ static Menu_t SaveMenu = {
 };
 
 static Menu_t SaveMenu_Rus = {
-    70 + ORIGWIDTH_DELTA, 30,
+    70, 30,
     DrawSaveMenu,
     6, SaveItems,
     0,
@@ -407,7 +407,7 @@ static MenuItem_t SkillItems_Rus[] = {
 };
 
 static Menu_t SkillMenu = {
-    38 + ORIGWIDTH_DELTA, 30,
+    38, 30,
     DrawSkillMenu,
     6, SkillItems,
     2,
@@ -415,7 +415,7 @@ static Menu_t SkillMenu = {
 };
 
 static Menu_t SkillMenu_Rus = {
-    38 + ORIGWIDTH_DELTA, 30,
+    38, 30,
     DrawSkillMenu,
     6, SkillItems_Rus,
     2,
@@ -448,7 +448,7 @@ static MenuItem_t OptionsItems_Rus[] = {
 };
 
 static Menu_t OptionsMenu = {
-    77 + ORIGWIDTH_DELTA, 16,
+    77, 16,
     NULL,
     7, OptionsItems,
     0,
@@ -456,7 +456,7 @@ static Menu_t OptionsMenu = {
 };
 
 static Menu_t OptionsMenu_Rus = {
-    77 + ORIGWIDTH_DELTA, 16,
+    77, 16,
     NULL,
     7, OptionsItems_Rus,
     0,
@@ -468,10 +468,10 @@ static Menu_t OptionsMenu_Rus = {
 // -----------------------------------------------------------------------------
 
 static MenuItem_t RenderingItems[] = {
+    {ITT_LRFUNC, "WIDESCREEN RENDERING:",           M_RD_Change_Widescreen, 0, MENU_NONE},
     {ITT_LRFUNC, "VERTICAL SYNCHRONIZATION:",       M_RD_Change_VSync, 0, MENU_NONE},
-    {ITT_LRFUNC, "FIX ASPECT RATIO:",               M_RD_AspectRatio,  0, MENU_NONE},
-    {ITT_LRFUNC, "UNCAPPED FRAMERATE:",             M_RD_Uncapped,     0, MENU_NONE},
-    {ITT_LRFUNC, "SHOW FPS COUNTER:",               M_RD_FPScounter,   0, MENU_NONE},
+    {ITT_LRFUNC, "FRAME RATE:",                     M_RD_Uncapped,     0, MENU_NONE},
+    {ITT_LRFUNC, "FPS COUNTER:",                    M_RD_FPScounter,   0, MENU_NONE},
     {ITT_LRFUNC, "PIXEL SCALING:",                  M_RD_Smoothing,    0, MENU_NONE},
     {ITT_LRFUNC, "VIDEO RENDERER:",                 M_RD_Renderer,     0, MENU_NONE},
     {ITT_EMPTY,  NULL,                              NULL,              0, MENU_NONE},
@@ -479,9 +479,9 @@ static MenuItem_t RenderingItems[] = {
 };
 
 static MenuItem_t RenderingItems_Rus[] = {
+    {ITT_LRFUNC, "IBHJRJAJHVFNYSQ HT;BV: D",        M_RD_Change_Widescreen, 0, MENU_NONE}, // ШИРОКОФОРМАТНЫЙ РЕЖИМ
     {ITT_LRFUNC, "DTHNBRFKMYFZ CBY[HJYBPFWBZ:",     M_RD_Change_VSync, 0, MENU_NONE}, // ВЕРТИКАЛЬНАЯ СИНХРОНИЗАЦИЯ
-    {ITT_LRFUNC, "ABRCBHJDFNM CJJNYJITYBT CNJHJY:", M_RD_AspectRatio,  0, MENU_NONE}, // ФИКСИРОВАТЬ СООТНОШЕНИЕ СТОРОН
-    {ITT_LRFUNC, "JUHFYBXTYBT RFLHJDJQ XFCNJNS:",   M_RD_Uncapped,     0, MENU_NONE}, // ОГРАНИЧЕНИЕ КАДРОВОЙ ЧАСТОТЫ
+    {ITT_LRFUNC, "RFLHJDFZ XFCNJNF:",               M_RD_Uncapped,     0, MENU_NONE}, // КАДРОВАЯ ЧАСТОТА
     {ITT_LRFUNC, "CXTNXBR RFLHJDJQ XFCNJNS:",       M_RD_FPScounter,   0, MENU_NONE}, // СЧЕТЧИК КАДРОВОЙ ЧАСТОТЫ
     {ITT_LRFUNC, "GBRCTKMYJT CUKF;BDFYBT:",         M_RD_Smoothing,    0, MENU_NONE}, // ПИКСЕЛЬНОЕ СГЛАЖИВАНИЕ
     {ITT_LRFUNC, "J,HF,JNRF DBLTJ:",                M_RD_Renderer,     0, MENU_NONE}, // ОБРАБОТКА ВИДЕО
@@ -490,7 +490,7 @@ static MenuItem_t RenderingItems_Rus[] = {
 };
 
 static Menu_t RenderingMenu = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawRenderingMenu,
     8, RenderingItems,
     0,
@@ -498,7 +498,7 @@ static Menu_t RenderingMenu = {
 };
 
 static Menu_t RenderingMenu_Rus = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawRenderingMenu,
     8, RenderingItems_Rus,
     0,
@@ -537,7 +537,7 @@ static MenuItem_t DisplayItems_Rus[] = {
 };
 
 static Menu_t DisplayMenu = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawDisplayMenu,
     10, DisplayItems,
     0,
@@ -545,7 +545,7 @@ static Menu_t DisplayMenu = {
 };
 
 static Menu_t DisplayMenu_Rus = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawDisplayMenu,
     10, DisplayItems_Rus,
     0,
@@ -581,7 +581,7 @@ static MenuItem_t SoundItems_Rus[] = {
 };
 
 static Menu_t SoundMenu = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawSoundMenu,
     9, SoundItems,
     0,
@@ -589,7 +589,7 @@ static Menu_t SoundMenu = {
 };
 
 static Menu_t SoundMenu_Rus = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawSoundMenu,
     9, SoundItems_Rus,
     0,
@@ -619,7 +619,7 @@ static MenuItem_t ControlsItems_Rus[] = {
 };
 
 static Menu_t ControlsMenu = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawControlsMenu,
     6, ControlsItems,
     0,
@@ -627,7 +627,7 @@ static Menu_t ControlsMenu = {
 };
 
 static Menu_t ControlsMenu_Rus = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawControlsMenu,
     6, ControlsItems_Rus,
     0,
@@ -667,7 +667,7 @@ static MenuItem_t Gameplay1Items_Rus[] = {
 };
 
 static Menu_t Gameplay1Menu = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawGameplay1Menu,
     11, Gameplay1Items,
     0,
@@ -675,7 +675,7 @@ static Menu_t Gameplay1Menu = {
 };
 
 static Menu_t Gameplay1Menu_Rus = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawGameplay1Menu,
     11, Gameplay1Items_Rus,
     0,
@@ -715,7 +715,7 @@ static MenuItem_t Gameplay2Items_Rus[] = {
 };
 
 static Menu_t Gameplay2Menu = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawGameplay2Menu,
     11, Gameplay2Items,
     0,
@@ -723,7 +723,7 @@ static Menu_t Gameplay2Menu = {
 };
 
 static Menu_t Gameplay2Menu_Rus = {
-    36 + ORIGWIDTH_DELTA, 42,
+    36, 42,
     DrawGameplay2Menu,
     11, Gameplay2Items_Rus,
     0,
@@ -817,6 +817,9 @@ void MN_Init(void)
     menuactive = false;
     messageson = true;
     SkullBaseLump = W_GetNumForName(DEH_String("M_SKL00"));
+
+    // [JN] Widescreen: set temp variable for rendering menu.
+    widescreen_temp = widescreen;
 
     if (gamemode == retail)
     {                           // Add episodes 4 and 5 to the menu
@@ -1281,23 +1284,23 @@ void MN_Drawer(void)
                                  QuitEndMsg_Rus[typeofask - 1]);
 
             if (english_language)
-            MN_DrTextA(message, 160 - MN_TextAWidth(message) / 2 + ORIGWIDTH_DELTA, 80);
+            MN_DrTextA(message, 160 - MN_TextAWidth(message) / 2 + wide_delta, 80);
             else
-            MN_DrTextSmallRUS(message, 160 - MN_DrTextSmallRUSWidth(message) / 2 + ORIGWIDTH_DELTA, 80);
+            MN_DrTextSmallRUS(message, 160 - MN_DrTextSmallRUSWidth(message) / 2 + wide_delta, 80);
 
             if (typeofask == 3)
             {
                 MN_DrTextA(SlotText[quicksave - 1], 160 -
-                           MN_TextAWidth(SlotText[quicksave - 1]) / 2 + ORIGWIDTH_DELTA, 90);
+                           MN_TextAWidth(SlotText[quicksave - 1]) / 2 + wide_delta, 90);
                 MN_DrTextA(DEH_String("?"), 160 +
-                           MN_TextAWidth(SlotText[quicksave - 1]) / 2 + ORIGWIDTH_DELTA, 90);
+                           MN_TextAWidth(SlotText[quicksave - 1]) / 2 + wide_delta, 90);
             }
             if (typeofask == 4)
             {
                 MN_DrTextA(SlotText[quickload - 1], 160 -
-                           MN_TextAWidth(SlotText[quickload - 1]) / 2 + ORIGWIDTH_DELTA, 90);
+                           MN_TextAWidth(SlotText[quickload - 1]) / 2 + wide_delta, 90);
                 MN_DrTextA(DEH_String("?"), 160 +
-                           MN_TextAWidth(SlotText[quickload - 1]) / 2 + ORIGWIDTH_DELTA, 90);
+                           MN_TextAWidth(SlotText[quickload - 1]) / 2 + wide_delta, 90);
             }
             UpdateState |= I_FULLSCRN;
         }
@@ -1336,11 +1339,11 @@ void MN_Drawer(void)
                     ||  CurrentMenu == &SkillMenu
                     ||  CurrentMenu == &OptionsMenu)
                     {
-                        MN_DrTextBigENG(DEH_String(item->text), x, y);
+                        MN_DrTextBigENG(DEH_String(item->text), x + wide_delta, y);
                     }
                     else
                     {
-                        MN_DrTextSmallENG(DEH_String(item->text), x, y);
+                        MN_DrTextSmallENG(DEH_String(item->text), x + wide_delta, y);
                     }
                 }
                 else
@@ -1351,11 +1354,11 @@ void MN_Drawer(void)
                     ||  CurrentMenu == &SkillMenu_Rus
                     ||  CurrentMenu == &OptionsMenu_Rus)
                     {
-                        MN_DrTextBigRUS(DEH_String(item->text), x, y);
+                        MN_DrTextBigRUS(DEH_String(item->text), x + wide_delta, y);
                     }
                     else
                     {
-                        MN_DrTextSmallRUS(DEH_String(item->text), x, y);
+                        MN_DrTextSmallRUS(DEH_String(item->text), x + wide_delta, y);
                     }
                 }
             }
@@ -1399,14 +1402,14 @@ void MN_Drawer(void)
         {
             y = CurrentMenu->y + (CurrentItPos * ITEM_HEIGHT) + SELECTOR_YOFFSET;
             selName = DEH_String(MenuTime & 16 ? "M_SLCTR1" : "M_SLCTR2");
-            V_DrawShadowedPatchRaven(x + SELECTOR_XOFFSET, y,
+            V_DrawShadowedPatchRaven(x + SELECTOR_XOFFSET + wide_delta, y,
                                      W_CacheLumpName(selName, PU_CACHE));
         }
         else
         {
             y = CurrentMenu->y + (CurrentItPos * ITEM_HEIGHT_SMALL) + SELECTOR_YOFFSET;
             selName = DEH_String(MenuTime & 8 ? "INVGEMR1" : "INVGEMR2");
-            V_DrawShadowedPatchRaven(x + SELECTOR_XOFFSET_SMALL, y,
+            V_DrawShadowedPatchRaven(x + SELECTOR_XOFFSET_SMALL + wide_delta, y,
                                      W_CacheLumpName(selName, PU_CACHE));
         }
     }
@@ -1423,10 +1426,10 @@ static void DrawMainMenu(void)
     int frame;
 
     frame = (MenuTime / 3) % 18;
-    V_DrawShadowedPatchRaven(88 + ORIGWIDTH_DELTA, 0, W_CacheLumpName(DEH_String("M_HTIC"), PU_CACHE));
-    V_DrawShadowedPatchRaven(40 + ORIGWIDTH_DELTA, 10, W_CacheLumpNum(SkullBaseLump + (17 - frame),
+    V_DrawShadowedPatchRaven(88 + wide_delta, 0, W_CacheLumpName(DEH_String("M_HTIC"), PU_CACHE));
+    V_DrawShadowedPatchRaven(40 + wide_delta, 10, W_CacheLumpNum(SkullBaseLump + (17 - frame),
                                        PU_CACHE));
-    V_DrawShadowedPatchRaven(232 + ORIGWIDTH_DELTA, 10, W_CacheLumpNum(SkullBaseLump + frame, PU_CACHE));
+    V_DrawShadowedPatchRaven(232 + wide_delta, 10, W_CacheLumpNum(SkullBaseLump + frame, PU_CACHE));
 }
 
 //---------------------------------------------------------------------------
@@ -1478,9 +1481,9 @@ static void DrawLoadMenu(void)
     title_rus = DEH_String("PFUHEPBNM BUHE");   // ЗАГРУЗИТЬ ИГРУ
 
     if (english_language)
-    MN_DrTextB(title_eng, 160 - MN_TextBWidth(title_eng) / 2 + ORIGWIDTH_DELTA, 7);
+    MN_DrTextB(title_eng, 160 - MN_TextBWidth(title_eng) / 2 + wide_delta, 7);
     else
-    MN_DrTextBigRUS(title_rus, 160 - MN_DrTextBigRUSWidth(title_rus) / 2 + ORIGWIDTH_DELTA, 7);
+    MN_DrTextBigRUS(title_rus, 160 - MN_DrTextBigRUSWidth(title_rus) / 2 + wide_delta, 7);
     
     if (!slottextloaded)
     {
@@ -1503,9 +1506,9 @@ static void DrawSaveMenu(void)
     title_rus = DEH_String("CJ[HFYBNM BUHE");   // СОХРАНИТЬ ИГРУ
 
     if (english_language)
-    MN_DrTextB(title_eng, 160 - MN_TextBWidth(title_eng) / 2 + ORIGWIDTH_DELTA, 7);
+    MN_DrTextB(title_eng, 160 - MN_TextBWidth(title_eng) / 2 + wide_delta, 7);
     else
-    MN_DrTextBigRUS(title_rus, 160 - MN_DrTextBigRUSWidth(title_rus) / 2 + ORIGWIDTH_DELTA, 7);
+    MN_DrTextBigRUS(title_rus, 160 - MN_DrTextBigRUSWidth(title_rus) / 2 + wide_delta, 7);
 
     if (!slottextloaded)
     {
@@ -1563,11 +1566,11 @@ static void DrawFileSlots(Menu_t * menu)
     y = menu->y;
     for (i = 0; i < 6; i++)
     {
-        V_DrawShadowedPatchRaven(x, y, W_CacheLumpName(DEH_String("M_FSLOT"), PU_CACHE));
+        V_DrawShadowedPatchRaven(x + wide_delta, y, W_CacheLumpName(DEH_String("M_FSLOT"), PU_CACHE));
         if (SlotStatus[i])
         {
             // [JN] Use only small English chars here
-            MN_DrTextSmallENG(SlotText[i], x + 5, y + 5);
+            MN_DrTextSmallENG(SlotText[i], x + 5 + wide_delta, y + 5);
         }
         y += ITEM_HEIGHT;
     }
@@ -1589,136 +1592,150 @@ static void DrawRenderingMenu(void)
     {
         // Title
         MN_DrTextBigENG(title_eng, 160 - MN_DrTextBigENGWidth(title_eng) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         // Subheaders
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallENG(DEH_String("RENDERING"), 36 + ORIGWIDTH_DELTA, 32);
-        MN_DrTextSmallENG(DEH_String("EXTRA"), 36 + ORIGWIDTH_DELTA, 102);
+        MN_DrTextSmallENG(DEH_String("RENDERING"), 36 + wide_delta, 32);
+        MN_DrTextSmallENG(DEH_String("EXTRA"), 36 + wide_delta, 102);
         dp_translation = NULL;
     }
     else
     {
         // Title
         MN_DrTextBigRUS(title_rus, 160 - MN_DrTextBigRUSWidth(title_rus) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         // Subheaders
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallRUS(DEH_String("HTYLTHBYU"), 36 + ORIGWIDTH_DELTA, 32);      // РЕНДЕРИНГ
-        MN_DrTextSmallRUS(DEH_String("LJGJKYBNTKMYJ"), 36 + ORIGWIDTH_DELTA, 102);  // ДОПОЛНИТЕЛЬНО
+        MN_DrTextSmallRUS(DEH_String("HTYLTHBYU"), 36 + wide_delta, 32);      // РЕНДЕРИНГ
+        MN_DrTextSmallRUS(DEH_String("LJGJKYBNTKMYJ"), 36 + wide_delta, 102);  // ДОПОЛНИТЕЛЬНО
         dp_translation = NULL;
     }
 
+    // - Widescreen rendering---------------------------------------------------
+    if (english_language)
+    {
+        MN_DrTextSmallENG(DEH_String(widescreen_temp == 1 ? "ON (16:9)" : "OFF (4:3)"),
+                                     193 + wide_delta, 42);
+        // Informative message
+        if (widescreen_temp != widescreen)
+        {
+            dp_translation = cr[CR_GRAY2GREEN_HERETIC];
+            MN_DrTextSmallENG(DEH_String("PROGRAM MUST BE RESTARTED"), 66 + wide_delta, 132);
+            dp_translation = NULL;
+        }
+    }
+    else
+    {
+        MN_DrTextSmallRUS(DEH_String(widescreen_temp == 1 ? "DRK (16:9)" : "DSRK (4:3)"),
+                                     212 + wide_delta, 42);
+        // Informative message: НЕОБХОДИМ ПЕРЕЗАПУСК ИГРЫ
+        if (widescreen_temp != widescreen)
+        {
+            dp_translation = cr[CR_GRAY2GREEN_HERETIC];
+            MN_DrTextSmallRUS(DEH_String("YTJ,[JLBV GTHTPFGECR GHJUHFVVS"), 46 + wide_delta, 132);
+            dp_translation = NULL;
+        }
+    }
 
     // - Vertical sync ---------------------------------------------------------
     if (vsync)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 216 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallENG(DEH_String("ON"), 216 + wide_delta, 52);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 236 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 236 + wide_delta, 52);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 216 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallENG(DEH_String("OFF"), 216 + wide_delta, 52);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 236 + ORIGWIDTH_DELTA, 42);
-    }
-
-    // - Fix aspect ratio ------------------------------------------------------
-    if (aspect_ratio_correct)
-    {
-#ifdef WIDESCREEN
-        MN_DrTextSmallENG(DEH_String("16:9"), (english_language ? 156 : 270) 
-                                            + ORIGWIDTH_DELTA, 52);
-#else
-        MN_DrTextSmallENG(DEH_String("4:3"), (english_language ? 156 : 270)
-                                           + ORIGWIDTH_DELTA, 52);
-#endif
-    }
-    else
-    {
-        if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 156 + ORIGWIDTH_DELTA, 52);
-        else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 270 + ORIGWIDTH_DELTA, 52);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 236 + wide_delta, 52);
     }
 
     // - Uncapped FPS ----------------------------------------------------------
-    if (uncapped_fps)
+    if (english_language)
     {
-        if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 184 + ORIGWIDTH_DELTA, 62);
-        else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 254 + ORIGWIDTH_DELTA, 62);
+        MN_DrTextSmallENG(DEH_String(uncapped_fps ? "UNCAPPED" : "35 FPS"), 120 + wide_delta, 62);
     }
     else
     {
-        MN_DrTextSmallENG(DEH_String("35 FPS"), (english_language ? 184 : 254) 
-                                              + ORIGWIDTH_DELTA, 62);
+        if (uncapped_fps)
+        MN_DrTextSmallRUS(DEH_String(",TP JUHFYBXTYBZ"), 165 + wide_delta, 62);
+        else
+        MN_DrTextSmallENG(DEH_String("35 FPS"), 165 + wide_delta, 62);
     }
 
     // - FPS counter -----------------------------------------------------------
     if (show_fps)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 165 + ORIGWIDTH_DELTA, 72);
+        MN_DrTextSmallENG(DEH_String("ON"), 129 + wide_delta, 72);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 223 + ORIGWIDTH_DELTA, 72);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 223 + wide_delta, 72);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 165 + ORIGWIDTH_DELTA, 72);
+        MN_DrTextSmallENG(DEH_String("OFF"), 129 + wide_delta, 72);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 223 + ORIGWIDTH_DELTA, 72);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 223 + wide_delta, 72);
     }
 
     // - Pixel scaling ---------------------------------------------------------
     if (smoothing)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("SMOOTH"), 131 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallENG(DEH_String("SMOOTH"), 131 + wide_delta, 82);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 211 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 211 + wide_delta, 82);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("SHARP"), 131 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallENG(DEH_String("SHARP"), 131 + wide_delta, 82);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 211 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 211 + wide_delta, 82);
     }
 
     // - Video renderer --------------------------------------------------------
     if (force_software_renderer)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("SOFTWARE (CPU)"), 149 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallENG(DEH_String("SOFTWARE (CPU)"), 149 + wide_delta, 92);
         else
-        MN_DrTextSmallRUS(DEH_String("GHJUHFVVYFZ"), 159 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallRUS(DEH_String("GHJUHFVVYFZ"), 159 + wide_delta, 92);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("HARDWARE (GPU)"), 149 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallENG(DEH_String("HARDWARE (GPU)"), 149 + wide_delta, 92);
         else
-        MN_DrTextSmallRUS(DEH_String("FGGFHFNYFZ"), 159 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallRUS(DEH_String("FGGFHFNYFZ"), 159 + wide_delta, 92);
     }
 
     // - Screenshot format --------------------------------------------------------
     if (png_screenshots)
     {
         MN_DrTextSmallENG(DEH_String("PNG"), (english_language ? 175 : 176)
-                                           + ORIGWIDTH_DELTA, 112);
+                                           + wide_delta, 112);
     }
     else
     {
         MN_DrTextSmallENG(DEH_String("PCX"), (english_language ? 175 : 176)
-                                           + ORIGWIDTH_DELTA, 112);
+                                           + wide_delta, 112);
     }   
+}
+
+static boolean M_RD_Change_Widescreen(int option)
+{
+    // [JN] Widescreen: changing only temp variable here.
+    // Initially it is set in MN_Init and stored into config file in M_QuitResponse.
+    widescreen_temp ^= 1;
+
+    return true;
 }
 
 static boolean M_RD_Change_VSync(int option)
@@ -1731,19 +1748,6 @@ static boolean M_RD_Change_VSync(int option)
 
     // Reinitialize graphics
     I_ReInitGraphics(REINIT_RENDERER | REINIT_TEXTURES | REINIT_ASPECTRATIO);
-
-    return true;
-}
-
-static boolean M_RD_AspectRatio(int option)
-{
-    aspect_ratio_correct ^= 1;
-
-    // Reinitialize graphics
-    I_ReInitGraphics(REINIT_RENDERER | REINIT_TEXTURES | REINIT_ASPECTRATIO);
-
-    // Update status bar
-    SB_state = -1;
 
     return true;
 }
@@ -1808,39 +1812,42 @@ static void DrawDisplayMenu(void)
     {
         // Title
         MN_DrTextBigENG(title_eng, 160 - MN_DrTextBigENGWidth(title_eng) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallENG(DEH_String("SCREEN"), 36 + ORIGWIDTH_DELTA, 32);
-        MN_DrTextSmallENG(DEH_String("MESSAGES AND TEXTS"), 36 + ORIGWIDTH_DELTA, 102);
+        MN_DrTextSmallENG(DEH_String("SCREEN"), 36 + wide_delta, 32);
+        MN_DrTextSmallENG(DEH_String("MESSAGES AND TEXTS"), 36 + wide_delta, 102);
         dp_translation = NULL;
     }
     else
     {
         // Title
         MN_DrTextBigRUS(title_rus, 160 - MN_DrTextBigRUSWidth(title_rus) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallRUS(DEH_String("\'RHFY"), 36 + ORIGWIDTH_DELTA, 32);              // ЭКРАН
-        MN_DrTextSmallRUS(DEH_String("CJJ,OTYBZ B NTRCNS"), 36 + ORIGWIDTH_DELTA, 102); // СООБЩЕНИЯ И ТЕКСТЫ
+        MN_DrTextSmallRUS(DEH_String("\'RHFY"), 36 + wide_delta, 32);              // ЭКРАН
+        MN_DrTextSmallRUS(DEH_String("CJJ,OTYBZ B NTRCNS"), 36 + wide_delta, 102); // СООБЩЕНИЯ И ТЕКСТЫ
         dp_translation = NULL;
     }
 
     // Screen size
-#ifdef WIDESCREEN
-    DrawSliderSmall((english_language ? &DisplayMenu : &DisplayMenu_Rus), 1, 4, screenblocks - 9);
-    M_snprintf(num, 4, "%3d", screenblocks);
-    dp_translation = cr[CR_GRAY2GDARKGRAY_HERETIC];
-    MN_DrTextSmallENG(num, 85 + ORIGWIDTH_DELTA, 52);
-    dp_translation = NULL;
-#else
-    DrawSliderSmall((english_language ? &DisplayMenu : &DisplayMenu_Rus), 1, 10, screenblocks - 3);
-    M_snprintf(num, 4, "%3d", screenblocks);
-    dp_translation = cr[CR_GRAY2GDARKGRAY_HERETIC];
-    MN_DrTextA(num, (english_language ? 208 : 202) + ORIGWIDTH_DELTA, 41);
-    dp_translation = NULL;
-#endif
+    if (widescreen)
+    {
+        DrawSliderSmall((english_language ? &DisplayMenu : &DisplayMenu_Rus), 1, 4, screenblocks - 9);
+        M_snprintf(num, 4, "%3d", screenblocks);
+        dp_translation = cr[CR_GRAY2GDARKGRAY_HERETIC];
+        MN_DrTextSmallENG(num, 85 + wide_delta, 52);
+        dp_translation = NULL;
+    }
+    else
+    {
+        DrawSliderSmall((english_language ? &DisplayMenu : &DisplayMenu_Rus), 1, 10, screenblocks - 3);
+        M_snprintf(num, 4, "%3d", screenblocks);
+        dp_translation = cr[CR_GRAY2GDARKGRAY_HERETIC];
+        MN_DrTextA(num, 135 + wide_delta, 52);
+        dp_translation = NULL;
+    }
 
     // Gamma-correction
     DrawSliderSmall((english_language ? &DisplayMenu : &DisplayMenu_Rus), 3, 18, usegamma);
@@ -1856,7 +1863,7 @@ static void DrawDisplayMenu(void)
                           local_time == 2 ? "12-HOUR (HH:MM:SS)" :
                           local_time == 3 ? "24-HOUR (HH:MM)" :
                           local_time == 4 ? "24-HOUR (HH:MM:SS)" : "OFF"),
-                          110 + ORIGWIDTH_DELTA, 112);
+                          110 + wide_delta, 112);
     }
     else
     {
@@ -1865,39 +1872,39 @@ static void DrawDisplayMenu(void)
                           local_time == 2 ? "12-XFCJDJT (XX:VV:CC)" :
                           local_time == 3 ? "24-XFCJDJT (XX:VV)" :
                           local_time == 4 ? "24-XFCJDJT (XX:VV:CC)" : "DSRK"),
-                          157 + ORIGWIDTH_DELTA, 112);
+                          157 + wide_delta, 112);
     }
 
     // Messages:
     if (messageson)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 108 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallENG(DEH_String("ON"), 108 + wide_delta, 122);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 208 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 208 + wide_delta, 122);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 108 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallENG(DEH_String("OFF"), 108 + wide_delta, 122);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 208 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 208 + wide_delta, 122);
     }
 
     // Text casting shadows:
     if (draw_shadowed_text)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 179 + ORIGWIDTH_DELTA, 132);
+        MN_DrTextSmallENG(DEH_String("ON"), 179 + wide_delta, 132);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 220 + ORIGWIDTH_DELTA, 132);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 220 + wide_delta, 132);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 179 + ORIGWIDTH_DELTA, 132);
+        MN_DrTextSmallENG(DEH_String("OFF"), 179 + wide_delta, 132);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 220 + ORIGWIDTH_DELTA, 132);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 220 + wide_delta, 132);
     }
 }
 
@@ -1915,14 +1922,15 @@ static boolean M_RD_ScreenSize(int option)
         screenblocks--;
     }
 
-#ifdef WIDESCREEN
-    // [JN] Wide screen: don't allow unsupported (bordered) views
-    // screenblocks - config file variable
-    if (screenblocks < 9)
-        screenblocks = 9;
-    if (screenblocks > 12)
-        screenblocks = 12;
-#endif
+    if (widescreen)
+    {
+        // [JN] Wide screen: don't allow unsupported (bordered) views
+        // screenblocks - config file variable
+        if (screenblocks < 9)
+            screenblocks = 9;
+        if (screenblocks > 12)
+            screenblocks = 12;
+    }
 
     R_SetViewSize(screenblocks, detailLevel);
     return true;
@@ -2034,22 +2042,22 @@ static void DrawSoundMenu(void)
     {
         // Title
         MN_DrTextBigENG(title_eng, 160 - MN_DrTextBigENGWidth(title_eng) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallENG(DEH_String("VOLUME"), 36 + ORIGWIDTH_DELTA, 32);
-        MN_DrTextSmallENG(DEH_String("EXTRA"), 36 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallENG(DEH_String("VOLUME"), 36 + wide_delta, 32);
+        MN_DrTextSmallENG(DEH_String("EXTRA"), 36 + wide_delta, 82);
         dp_translation = NULL;
     }
     else
     {
         // Title
         MN_DrTextBigRUS(title_rus, 160 - MN_DrTextBigRUSWidth(title_rus) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallRUS(DEH_String("UHJVRJCNM"), 36 + ORIGWIDTH_DELTA, 32);       // ГРОМКОСТЬ
-        MN_DrTextSmallRUS(DEH_String("LJGJKYBNTKMYJ"), 36 + ORIGWIDTH_DELTA, 82);   // ДОПОЛНИТЕЛЬНО
+        MN_DrTextSmallRUS(DEH_String("UHJVRJCNM"), 36 + wide_delta, 32);       // ГРОМКОСТЬ
+        MN_DrTextSmallRUS(DEH_String("LJGJKYBNTKMYJ"), 36 + wide_delta, 82);   // ДОПОЛНИТЕЛЬНО
         dp_translation = NULL;
     }
 
@@ -2057,53 +2065,53 @@ static void DrawSoundMenu(void)
     DrawSliderSmall((english_language ? &SoundMenu : &SoundMenu_Rus), 1, 16, snd_MaxVolume);
     M_snprintf(num, 4, "%3d", snd_MaxVolume);
     dp_translation = cr[CR_GRAY2GDARKGRAY_HERETIC];
-    MN_DrTextSmallENG(num, 184 + ORIGWIDTH_DELTA, 53);
+    MN_DrTextSmallENG(num, 184 + wide_delta, 53);
     dp_translation = NULL;
 
     // Music Volume
     DrawSliderSmall((english_language ? &SoundMenu : &SoundMenu_Rus), 3, 16, snd_MusicVolume);
     M_snprintf(num, 4, "%3d", snd_MusicVolume);
     dp_translation = cr[CR_GRAY2GDARKGRAY_HERETIC];
-    MN_DrTextSmallENG(num, 184 + ORIGWIDTH_DELTA, 73);
+    MN_DrTextSmallENG(num, 184 + wide_delta, 73);
     dp_translation = NULL;
 
     // SFX Channels
     DrawSliderSmall((english_language ? &SoundMenu : &SoundMenu_Rus), 6, 16, snd_Channels / 4 - 1);
     M_snprintf(num, 4, "%3d", snd_Channels);
     dp_translation = cr[CR_GRAY2GDARKGRAY_HERETIC];
-    MN_DrTextSmallENG(num, 184 + ORIGWIDTH_DELTA, 103);
+    MN_DrTextSmallENG(num, 184 + wide_delta, 103);
     dp_translation = NULL;
 
     // SFX Mode
     if (snd_monomode)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("MONO"), 105 + ORIGWIDTH_DELTA, 112);
+        MN_DrTextSmallENG(DEH_String("MONO"), 105 + wide_delta, 112);
         else
-        MN_DrTextSmallRUS(DEH_String("VJYJ"), 128 + ORIGWIDTH_DELTA, 112);
+        MN_DrTextSmallRUS(DEH_String("VJYJ"), 128 + wide_delta, 112);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("STEREO"), 105 + ORIGWIDTH_DELTA, 112);
+        MN_DrTextSmallENG(DEH_String("STEREO"), 105 + wide_delta, 112);
         else
-        MN_DrTextSmallRUS(DEH_String("CNTHTJ"), 128 + ORIGWIDTH_DELTA, 112);
+        MN_DrTextSmallRUS(DEH_String("CNTHTJ"), 128 + wide_delta, 112);
     }    
 
     // Pitch-Shifted sounds
     if (snd_pitchshift)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 189 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallENG(DEH_String("ON"), 189 + wide_delta, 122);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 230 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 230 + wide_delta, 122);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 189 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallENG(DEH_String("OFF"), 189 + wide_delta, 122);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 230 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 230 + wide_delta, 122);
     }
 }
 
@@ -2192,22 +2200,22 @@ static void DrawControlsMenu(void)
     {
         // Title
         MN_DrTextBigENG(title_eng, 160 - MN_DrTextBigENGWidth(title_eng) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallENG(DEH_String("MOVEMENT"), 36 + ORIGWIDTH_DELTA, 32);
-        MN_DrTextSmallENG(DEH_String("MOUSE"), 36 + ORIGWIDTH_DELTA, 52);
+        MN_DrTextSmallENG(DEH_String("MOVEMENT"), 36 + wide_delta, 32);
+        MN_DrTextSmallENG(DEH_String("MOUSE"), 36 + wide_delta, 52);
         dp_translation = NULL;
     }
     else
     {
         // Title
         MN_DrTextBigRUS(title_rus, 160 - MN_DrTextBigRUSWidth(title_rus) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallRUS(DEH_String("GTHTLDB;TYBT"), 36 + ORIGWIDTH_DELTA, 32);    // ПЕРЕДВИЖЕНИЕ
-        MN_DrTextSmallRUS(DEH_String("VSIM"), 36 + ORIGWIDTH_DELTA, 52);            // МЫШЬ
+        MN_DrTextSmallRUS(DEH_String("GTHTLDB;TYBT"), 36 + wide_delta, 32);    // ПЕРЕДВИЖЕНИЕ
+        MN_DrTextSmallRUS(DEH_String("VSIM"), 36 + wide_delta, 52);            // МЫШЬ
         dp_translation = NULL;
     }
 
@@ -2215,55 +2223,55 @@ static void DrawControlsMenu(void)
     if (joybspeed >= 20)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 118 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallENG(DEH_String("ON"), 118 + wide_delta, 42);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 209 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 209 + wide_delta, 42);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 118 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallENG(DEH_String("OFF"), 118 + wide_delta, 42);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 209 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 209 + wide_delta, 42);
     }
 
     // Mouse sensivity
     DrawSliderSmall((english_language ? &ControlsMenu : &ControlsMenu_Rus), 3, 12, mouseSensitivity);
     M_snprintf(num, 4, "%3d", mouseSensitivity);
     dp_translation = cr[CR_GRAY2GDARKGRAY_HERETIC];
-    MN_DrTextSmallENG(num, 152 + ORIGWIDTH_DELTA, 73);
+    MN_DrTextSmallENG(num, 152 + wide_delta, 73);
     dp_translation = NULL;
 
     // Mouse look
     if (mlook)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 118 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallENG(DEH_String("ON"), 118 + wide_delta, 82);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 132 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 132 + wide_delta, 82);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 118 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallENG(DEH_String("OFF"), 118 + wide_delta, 82);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 132 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 132 + wide_delta, 82);
     }
 
     // Novert
     if (!novert)
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 168 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallENG(DEH_String("ON"), 168 + wide_delta, 92);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 227 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 227 + wide_delta, 92);
     }
     else
     {
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 168 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallENG(DEH_String("OFF"), 168 + wide_delta, 92);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 227 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 227 + wide_delta, 92);
     }
 }
 
@@ -2330,22 +2338,22 @@ static void DrawGameplay1Menu(void)
     {
         // Title
         MN_DrTextBigENG(title_eng, 160 - MN_DrTextBigENGWidth(title_eng) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallENG(DEH_String("VISUAL"), 36 + ORIGWIDTH_DELTA, 32);
-        MN_DrTextSmallENG(DEH_String("TACTICAL"), 36 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallENG(DEH_String("VISUAL"), 36 + wide_delta, 32);
+        MN_DrTextSmallENG(DEH_String("TACTICAL"), 36 + wide_delta, 92);
         dp_translation = NULL;
     }
     else
     {
         // Title
         MN_DrTextBigRUS(title_rus, 160 - MN_DrTextBigRUSWidth(title_rus) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallRUS(DEH_String("UHFABRF"), 36 + ORIGWIDTH_DELTA, 32); // ГРАФИКА
-        MN_DrTextSmallRUS(DEH_String("NFRNBRF"), 36 + ORIGWIDTH_DELTA, 92); // ТАКТИКА
+        MN_DrTextSmallRUS(DEH_String("UHFABRF"), 36 + wide_delta, 32); // ГРАФИКА
+        MN_DrTextSmallRUS(DEH_String("NFRNBRF"), 36 + wide_delta, 92); // ТАКТИКА
         dp_translation = NULL;
     }
 
@@ -2355,9 +2363,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 119 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallENG(DEH_String("ON"), 119 + wide_delta, 42);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 133 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 133 + wide_delta, 42);
 
         dp_translation = NULL;
     }
@@ -2366,9 +2374,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 119 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallENG(DEH_String("OFF"), 119 + wide_delta, 42);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 133 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 133 + wide_delta, 42);
 
         dp_translation = NULL;
     }
@@ -2379,9 +2387,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 143 + ORIGWIDTH_DELTA, 52);
+        MN_DrTextSmallENG(DEH_String("ON"), 143 + wide_delta, 52);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 205 + ORIGWIDTH_DELTA, 52);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 205 + wide_delta, 52);
 
         dp_translation = NULL;
     }
@@ -2390,9 +2398,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 143 + ORIGWIDTH_DELTA, 52);
+        MN_DrTextSmallENG(DEH_String("OFF"), 143 + wide_delta, 52);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 205 + ORIGWIDTH_DELTA, 52);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 205 + wide_delta, 52);
 
         dp_translation = NULL;
     }
@@ -2403,9 +2411,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 126 + ORIGWIDTH_DELTA, 62);
+        MN_DrTextSmallENG(DEH_String("ON"), 126 + wide_delta, 62);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 235 + ORIGWIDTH_DELTA, 62);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 235 + wide_delta, 62);
 
         dp_translation = NULL;
     }
@@ -2414,9 +2422,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 126 + ORIGWIDTH_DELTA, 62);
+        MN_DrTextSmallENG(DEH_String("OFF"), 126 + wide_delta, 62);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 235 + ORIGWIDTH_DELTA, 62);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 235 + wide_delta, 62);
 
         dp_translation = NULL;
     }
@@ -2428,9 +2436,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 139 + ORIGWIDTH_DELTA, 72);
+        MN_DrTextSmallENG(DEH_String("ON"), 139 + wide_delta, 72);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 178 + ORIGWIDTH_DELTA, 72);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 178 + wide_delta, 72);
 
         dp_translation = NULL;
     }
@@ -2439,9 +2447,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 139 + ORIGWIDTH_DELTA, 72);
+        MN_DrTextSmallENG(DEH_String("OFF"), 139 + wide_delta, 72);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 178 + ORIGWIDTH_DELTA, 72);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 178 + wide_delta, 72);
 
         dp_translation = NULL;
     }
@@ -2452,9 +2460,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 235 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallENG(DEH_String("ON"), 235 + wide_delta, 82);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 253 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 253 + wide_delta, 82);
 
         dp_translation = NULL;
     }
@@ -2463,9 +2471,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 235 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallENG(DEH_String("OFF"), 235 + wide_delta, 82);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 253 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 253 + wide_delta, 82);
 
         dp_translation = NULL;
     }
@@ -2476,9 +2484,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 240 + ORIGWIDTH_DELTA, 102);
+        MN_DrTextSmallENG(DEH_String("ON"), 240 + wide_delta, 102);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 231 + ORIGWIDTH_DELTA, 102);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 231 + wide_delta, 102);
 
         dp_translation = NULL;
     }
@@ -2487,9 +2495,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 240 + ORIGWIDTH_DELTA, 102);
+        MN_DrTextSmallENG(DEH_String("OFF"), 240 + wide_delta, 102);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 231 + ORIGWIDTH_DELTA, 102);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 231 + wide_delta, 102);
 
         dp_translation = NULL;
     }
@@ -2500,9 +2508,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 235 + ORIGWIDTH_DELTA, 112);
+        MN_DrTextSmallENG(DEH_String("ON"), 235 + wide_delta, 112);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 251 + ORIGWIDTH_DELTA, 112);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 251 + wide_delta, 112);
 
         dp_translation = NULL;
     }
@@ -2511,9 +2519,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 235 + ORIGWIDTH_DELTA, 112);
+        MN_DrTextSmallENG(DEH_String("OFF"), 235 + wide_delta, 112);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 251 + ORIGWIDTH_DELTA, 112);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 251 + wide_delta, 112);
 
         dp_translation = NULL;
     }
@@ -2524,9 +2532,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 190 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallENG(DEH_String("ON"), 190 + wide_delta, 122);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 253 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 253 + wide_delta, 122);
 
         dp_translation = NULL;
     }
@@ -2535,9 +2543,9 @@ static void DrawGameplay1Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 190 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallENG(DEH_String("OFF"), 190 + wide_delta, 122);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 253 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 253 + wide_delta, 122);
 
         dp_translation = NULL;
     }
@@ -2607,24 +2615,24 @@ static void DrawGameplay2Menu(void)
     {
         // Title
         MN_DrTextBigENG(title_eng, 160 - MN_DrTextBigENGWidth(title_eng) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallENG(DEH_String("PHYSICAL"), 36 + ORIGWIDTH_DELTA, 32);
-        MN_DrTextSmallENG(DEH_String("CROSSHAIR"), 36 + ORIGWIDTH_DELTA, 72);
-        MN_DrTextSmallENG(DEH_String("GAMEPLAY"), 36 + ORIGWIDTH_DELTA, 112);
+        MN_DrTextSmallENG(DEH_String("PHYSICAL"), 36 + wide_delta, 32);
+        MN_DrTextSmallENG(DEH_String("CROSSHAIR"), 36 + wide_delta, 72);
+        MN_DrTextSmallENG(DEH_String("GAMEPLAY"), 36 + wide_delta, 112);
         dp_translation = NULL;
     }
     else
     {
         // Title
         MN_DrTextBigRUS(title_rus, 160 - MN_DrTextBigRUSWidth(title_rus) / 2 
-                                       + ORIGWIDTH_DELTA, 7);
+                                       + wide_delta, 7);
 
         dp_translation = cr[CR_GRAY2DARKGOLD_HERETIC];
-        MN_DrTextSmallRUS(DEH_String("UHFABRF"), 36 + ORIGWIDTH_DELTA, 32);    // ФИЗИКА
-        MN_DrTextSmallRUS(DEH_String("GHBWTK"), 36 + ORIGWIDTH_DELTA, 72);     // ПРИЦЕЛ
-        MN_DrTextSmallRUS(DEH_String("UTQVGKTQ"), 36 + ORIGWIDTH_DELTA, 112);  // ГЕЙМПЛЕЙ
+        MN_DrTextSmallRUS(DEH_String("UHFABRF"), 36 + wide_delta, 32);    // ФИЗИКА
+        MN_DrTextSmallRUS(DEH_String("GHBWTK"), 36 + wide_delta, 72);     // ПРИЦЕЛ
+        MN_DrTextSmallRUS(DEH_String("UTQVGKTQ"), 36 + wide_delta, 112);  // ГЕЙМПЛЕЙ
         dp_translation = NULL;
     }
 
@@ -2634,9 +2642,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 238 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallENG(DEH_String("ON"), 238 + wide_delta, 42);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 248 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 248 + wide_delta, 42);
 
         dp_translation = NULL;
     }
@@ -2645,9 +2653,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 238 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallENG(DEH_String("OFF"), 238 + wide_delta, 42);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 248 + ORIGWIDTH_DELTA, 42);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 248 + wide_delta, 42);
 
         dp_translation = NULL;
     }
@@ -2658,9 +2666,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 233 + ORIGWIDTH_DELTA, 52);
+        MN_DrTextSmallENG(DEH_String("ON"), 233 + wide_delta, 52);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 260 + ORIGWIDTH_DELTA, 52);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 260 + wide_delta, 52);
 
         dp_translation = NULL;
     }
@@ -2669,9 +2677,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 233 + ORIGWIDTH_DELTA, 52);
+        MN_DrTextSmallENG(DEH_String("OFF"), 233 + wide_delta, 52);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 260 + ORIGWIDTH_DELTA, 52);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 260 + wide_delta, 52);
 
         dp_translation = NULL;
     }
@@ -2682,9 +2690,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 232 + ORIGWIDTH_DELTA, 62);
+        MN_DrTextSmallENG(DEH_String("ON"), 232 + wide_delta, 62);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 201 + ORIGWIDTH_DELTA, 62);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 201 + wide_delta, 62);
 
         dp_translation = NULL;
     }
@@ -2693,9 +2701,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 232 + ORIGWIDTH_DELTA, 62);
+        MN_DrTextSmallENG(DEH_String("OFF"), 232 + wide_delta, 62);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 201 + ORIGWIDTH_DELTA, 62);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 201 + wide_delta, 62);
 
         dp_translation = NULL;
     }
@@ -2706,9 +2714,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 150 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallENG(DEH_String("ON"), 150 + wide_delta, 82);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 175 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 175 + wide_delta, 82);
 
         dp_translation = NULL;
     }
@@ -2717,9 +2725,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 150 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallENG(DEH_String("OFF"), 150 + wide_delta, 82);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 175 + ORIGWIDTH_DELTA, 82);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 175 + wide_delta, 82);
 
         dp_translation = NULL;
     }
@@ -2730,9 +2738,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 161 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallENG(DEH_String("ON"), 161 + wide_delta, 92);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 179 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 179 + wide_delta, 92);
 
         dp_translation = NULL;
     }
@@ -2741,9 +2749,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 161 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallENG(DEH_String("OFF"), 161 + wide_delta, 92);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 179 + ORIGWIDTH_DELTA, 92);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 179 + wide_delta, 92);
 
         dp_translation = NULL;
     }
@@ -2754,9 +2762,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 146 + ORIGWIDTH_DELTA, 102);
+        MN_DrTextSmallENG(DEH_String("ON"), 146 + wide_delta, 102);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 181 + ORIGWIDTH_DELTA, 102);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 181 + wide_delta, 102);
 
         dp_translation = NULL;
     }
@@ -2765,9 +2773,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 146 + ORIGWIDTH_DELTA, 102);
+        MN_DrTextSmallENG(DEH_String("OFF"), 146 + wide_delta, 102);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 181 + ORIGWIDTH_DELTA, 102);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 181 + wide_delta, 102);
 
         dp_translation = NULL;
     }
@@ -2778,9 +2786,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 153 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallENG(DEH_String("ON"), 153 + wide_delta, 122);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 255 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 255 + wide_delta, 122);
 
         dp_translation = NULL;
     }
@@ -2789,9 +2797,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 153 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallENG(DEH_String("OFF"), 153 + wide_delta, 122);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 255 + ORIGWIDTH_DELTA, 122);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 255 + wide_delta, 122);
 
         dp_translation = NULL;
     }
@@ -2802,9 +2810,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2RED_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("OFF"), 179 + ORIGWIDTH_DELTA, 132);
+        MN_DrTextSmallENG(DEH_String("OFF"), 179 + wide_delta, 132);
         else
-        MN_DrTextSmallRUS(DEH_String("DSRK"), 211 + ORIGWIDTH_DELTA, 132);
+        MN_DrTextSmallRUS(DEH_String("DSRK"), 211 + wide_delta, 132);
 
         dp_translation = NULL;
     }
@@ -2813,9 +2821,9 @@ static void DrawGameplay2Menu(void)
         dp_translation = cr[CR_GRAY2GREEN_HERETIC];
 
         if (english_language)
-        MN_DrTextSmallENG(DEH_String("ON"), 179 + ORIGWIDTH_DELTA, 132);
+        MN_DrTextSmallENG(DEH_String("ON"), 179 + wide_delta, 132);
         else
-        MN_DrTextSmallRUS(DEH_String("DRK"), 211 + ORIGWIDTH_DELTA, 132);
+        MN_DrTextSmallRUS(DEH_String("DRK"), 211 + wide_delta, 132);
 
         dp_translation = NULL;
     }
@@ -3289,6 +3297,9 @@ boolean MN_Responder(event_t * event)
           && (event->data1 == key_menu_activate
            || event->data1 == key_menu_quit)))
         {
+            // [JN] Widescreen: remember choosen widescreen variable before quit.
+            widescreen = widescreen_temp;
+
             I_Quit();
             return true;
         }
@@ -3305,6 +3316,9 @@ boolean MN_Responder(event_t * event)
         if (!menuactive && askforquit && typeofask == 1)
         {
             G_CheckDemoStatus();
+
+            // [JN] Widescreen: remember choosen widescreen variable before quit.
+            widescreen = widescreen_temp;
             I_Quit();
         }
         else
@@ -3374,6 +3388,8 @@ boolean MN_Responder(event_t * event)
             {
                 case 1:
                     G_CheckDemoStatus();
+                    // [JN] Widescreen: remember choosen widescreen variable before quit.
+                    widescreen = widescreen_temp;
                     I_Quit();
                     return false;
 
@@ -3941,11 +3957,12 @@ void MN_DeactivateMenu(void)
 
 void MN_DrawInfo(void)
 {
-#ifdef WIDESCREEN
-    // [JN] Clean up remainings of the wide screen before 
-    // drawing a HELP or TITLE screens.
-    V_DrawFilledBox(0, 0, SCREENWIDTH, SCREENHEIGHT, 0);
-#endif
+    if (widescreen)
+    {
+        // [JN] Clean up remainings of the wide screen before 
+        // drawing a HELP or TITLE screens.
+        V_DrawFilledBox(0, 0, WIDESCREENWIDTH, SCREENHEIGHT, 0);
+    }
 
     I_SetPalette(W_CacheLumpName(usegamma <= 8 ?
                                  "PALFIX" :
@@ -4086,21 +4103,21 @@ static void DrawSliderSmall(Menu_t * menu, int item, int width, int slot)
     x = menu->x + 24;
     y = menu->y + (item * ITEM_HEIGHT_SMALL);
 
-    V_DrawShadowedPatchRaven(x - 32, y, W_CacheLumpName(DEH_String("M_RDSLDL"), PU_CACHE));
+    V_DrawShadowedPatchRaven(x - 32 + wide_delta, y, W_CacheLumpName(DEH_String("M_RDSLDL"), PU_CACHE));
 
     for (x2 = x, count = width; count--; x2 += 8)
     {
-        V_DrawShadowedPatchRaven(x2 - 16, y, W_CacheLumpName(DEH_String("M_RDSLD1"), PU_CACHE));
+        V_DrawShadowedPatchRaven(x2 - 16 + wide_delta, y, W_CacheLumpName(DEH_String("M_RDSLD1"), PU_CACHE));
     }
 
-    V_DrawShadowedPatchRaven(x2 - 25, y, W_CacheLumpName(DEH_String("M_RDSLDR"), PU_CACHE));
+    V_DrawShadowedPatchRaven(x2 - 25 + wide_delta, y, W_CacheLumpName(DEH_String("M_RDSLDR"), PU_CACHE));
 
     // [JN] Colorizing slider gem...
     // Most left position (dull green gem)
     if (slot == 0)
     {
         dp_translation = cr[CR_GREEN2GRAY_HERETIC];
-        V_DrawPatch(x + slot * 8, y + 7, W_CacheLumpName(DEH_String("M_RDSLG"), PU_CACHE));
+        V_DrawPatch(x + slot * 8 + wide_delta, y + 7, W_CacheLumpName(DEH_String("M_RDSLG"), PU_CACHE));
         dp_translation = NULL;
     }
     // [JN] Most right position that is "out of bounds" (red gem).
@@ -4109,10 +4126,10 @@ static void DrawSliderSmall(Menu_t * menu, int item, int width, int slot)
     {
         slot = 11;
         dp_translation = cr[CR_GREEN2RED_HERETIC];
-        V_DrawPatch(x + slot * 8, y + 7, W_CacheLumpName(DEH_String("M_RDSLG"), PU_CACHE));
+        V_DrawPatch(x + slot * 8 + wide_delta, y + 7, W_CacheLumpName(DEH_String("M_RDSLG"), PU_CACHE));
         dp_translation = NULL;
     }
     // [JN] Standard function (green gem)
     else
-    V_DrawPatch(x + slot * 8, y + 7, W_CacheLumpName(DEH_String("M_RDSLG"), PU_CACHE));
+    V_DrawPatch(x + slot * 8 + wide_delta, y + 7, W_CacheLumpName(DEH_String("M_RDSLG"), PU_CACHE));
 }

--- a/src/heretic/p_mobj.c
+++ b/src/heretic/p_mobj.c
@@ -1615,28 +1615,33 @@ mobj_t *P_SpawnPlayerMissile(mobj_t * source, mobjtype_t type)
         {
             an = source->angle;
 
-#ifdef WIDESCREEN
-        // [JN] Wide screen: new magic number :(
-        slope = ((source->player->lookdir / MLOOKUNIT) << FRACBITS) / 240;
-#else
-        slope = ((source->player->lookdir / MLOOKUNIT) << FRACBITS) /
-                 (screenblocks <= 10 ? 161 : 146);
-#endif
-
+        if (widescreen)
+        {
+            // [JN] Wide screen: new magic number :(
+            slope = ((source->player->lookdir / MLOOKUNIT) << FRACBITS) / 177;
+        }
+        else
+        {
+            slope = ((source->player->lookdir / MLOOKUNIT) << FRACBITS) /
+                    (screenblocks <= 10 ? 161 : 146);
+        }
         }
     }
     x = source->x;
     y = source->y;
 
-#ifdef WIDESCREEN
+    if (widescreen)
+    {
         // [JN] Wide screen: new magic number :(
         z = source->z + 4 * 8 * FRACUNIT +
-        ((source->player->lookdir / MLOOKUNIT) << FRACBITS) / 240;
-#else
-    z = source->z + 4 * 8 * FRACUNIT +
-        ((source->player->lookdir / MLOOKUNIT) << FRACBITS) /
-         (screenblocks <= 10 ? 161 : 146);
-#endif
+        ((source->player->lookdir / MLOOKUNIT) << FRACBITS) / 177;
+    }
+    else
+    {
+        z = source->z + 4 * 8 * FRACUNIT +
+            ((source->player->lookdir / MLOOKUNIT) << FRACBITS) /
+            (screenblocks <= 10 ? 161 : 146);
+    }
 
     if (source->flags2 & MF2_FEETARECLIPPED)
     {
@@ -1704,28 +1709,33 @@ mobj_t *P_SPMAngle(mobj_t * source, mobjtype_t type, angle_t angle)
         {
             an = angle;
 
-#ifdef WIDESCREEN
-        // [JN] Wide screen: new magic number :(
-        slope = ((source->player->lookdir / MLOOKUNIT) << FRACBITS) / 240;
-#else
-        slope = ((source->player->lookdir / MLOOKUNIT) << FRACBITS) /
-                 (screenblocks <= 10 ? 161 : 146);
-#endif
-
+        if (widescreen)
+        {
+            // [JN] Wide screen: new magic number :(
+            slope = ((source->player->lookdir / MLOOKUNIT) << FRACBITS) / 177;
+        }
+        else
+        {
+            slope = ((source->player->lookdir / MLOOKUNIT) << FRACBITS) /
+                    (screenblocks <= 10 ? 161 : 146);
+        }
         }
     }
     x = source->x;
     y = source->y;
 
-#ifdef WIDESCREEN
-    // [JN] Wide screen: new magic number :(
-    z = source->z + 4 * 8 * FRACUNIT +
-    ((source->player->lookdir / MLOOKUNIT) << FRACBITS) / 240;
-#else
-    z = source->z + 4 * 8 * FRACUNIT +
-        ((source->player->lookdir / MLOOKUNIT) << FRACBITS) /
-         (screenblocks <= 10 ? 161 : 146);
-#endif
+    if (widescreen)
+    {
+        // [JN] Wide screen: new magic number :(
+        z = source->z + 4 * 8 * FRACUNIT +
+        ((source->player->lookdir / MLOOKUNIT) << FRACBITS) / 177;
+    }
+    else
+    {
+        z = source->z + 4 * 8 * FRACUNIT +
+            ((source->player->lookdir / MLOOKUNIT) << FRACBITS) /
+            (screenblocks <= 10 ? 161 : 146);
+    }
 
     if (source->flags2 & MF2_FEETARECLIPPED)
     {

--- a/src/heretic/p_pspr.c
+++ b/src/heretic/p_pspr.c
@@ -821,14 +821,16 @@ void P_BulletSlope(mobj_t * mo)
         {
             an += 2 << 26;
 
-#ifdef WIDESCREEN
-            // [JN] Wide screen: new magic number :(
-            bulletslope = (mo->player->lookdir / MLOOKUNIT << FRACBITS) / 240;
-#else
-            bulletslope = (mo->player->lookdir / MLOOKUNIT << FRACBITS) /
-                          (screenblocks <= 10 ? 161 : 146);
-#endif
-
+            if (widescreen)
+            {
+                // [JN] Wide screen: new magic number :(
+                bulletslope = (mo->player->lookdir / MLOOKUNIT << FRACBITS) / 177;
+            }
+            else
+            {
+                bulletslope = (mo->player->lookdir / MLOOKUNIT << FRACBITS) /
+                            (screenblocks <= 10 ? 161 : 146);
+            }
         }
     }
 }

--- a/src/heretic/r_bsp.c
+++ b/src/heretic/r_bsp.c
@@ -74,7 +74,7 @@ typedef struct
 // render overage and then bomb out by detecting the overflow after the 
 // fact. -haleyjd
 //#define MAXSEGS 32
-#define MAXSEGS (SCREENWIDTH / 2 + 1)
+#define MAXSEGS (WIDESCREENWIDTH / 2 + 1)
 
 cliprange_t solidsegs[MAXSEGS], *newend;        // newend is one past the last valid seg
 

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -34,8 +34,7 @@ files only know about ccordinates, not the architecture of the frame buffer.
 byte *viewimage;
 int viewwidth, scaledviewwidth, viewheight, viewwindowx, viewwindowy;
 byte *ylookup[MAXHEIGHT];
-int columnofs[MAXWIDTH];
-int linesize = SCREENWIDTH;
+int columnofs[WIDEMAXWIDTH];
 byte translations[3][256];      // color tables for different players
 
 /*
@@ -72,7 +71,7 @@ void R_DrawColumn(void)
     return;
 
 #ifdef RANGECHECK
-    if ((unsigned)dc_x >= SCREENWIDTH || dc_yl < 0 || dc_yh >= SCREENHEIGHT)
+    if ((unsigned)dc_x >= screenwidth || dc_yl < 0 || dc_yh >= SCREENHEIGHT)
         I_Error (english_language ?
                  "R_DrawColumn: %i to %i at %i" :
                  "R_DrawColumn: %i к %i в %i",
@@ -119,7 +118,7 @@ void R_DrawColumn(void)
                 // heightmask is the Tutti-Frutti fix -- killough
 
                 *dest = colormap[source[frac>>FRACBITS]];
-                dest += linesize;                     // killough 11/98
+                dest += screenwidth;                     // killough 11/98
                 if ((frac += fracstep) >= heightmask)
                     frac -= heightmask;
             }
@@ -130,10 +129,10 @@ void R_DrawColumn(void)
             while ((count-=2)>=0)   // texture height is a power of 2 -- killough
             {
                 *dest = colormap[source[(frac>>FRACBITS) & heightmask]];
-                dest += linesize;   // killough 11/98
+                dest += screenwidth;   // killough 11/98
                 frac += fracstep;
                 *dest = colormap[source[(frac>>FRACBITS) & heightmask]];
-                dest += linesize;   // killough 11/98
+                dest += screenwidth;   // killough 11/98
                 frac += fracstep;
             }
             if (count & 1)
@@ -153,7 +152,7 @@ void R_DrawColumnLow(void)
         return;
 
 #ifdef RANGECHECK
-    if ((unsigned) dc_x >= SCREENWIDTH || dc_yl < 0 || dc_yh >= SCREENHEIGHT)
+    if ((unsigned) dc_x >= screenwidth || dc_yl < 0 || dc_yh >= SCREENHEIGHT)
         I_Error(english_language ?
                 "R_DrawColumn: %i to %i at %i" :
                 "R_DrawColumn: %i к %i в %i",
@@ -169,7 +168,7 @@ void R_DrawColumnLow(void)
     do
     {
         *dest = dc_colormap[dc_source[(frac >> FRACBITS) & 127]];
-        dest += SCREENWIDTH;
+        dest += screenwidth;
         frac += fracstep;
     }
     while (count--);
@@ -197,7 +196,7 @@ void R_DrawTLColumn(void)
         return;
 
 #ifdef RANGECHECK
-    if ((unsigned) dc_x >= SCREENWIDTH || dc_yl < 0 || dc_yh >= SCREENHEIGHT)
+    if ((unsigned) dc_x >= screenwidth || dc_yl < 0 || dc_yh >= SCREENHEIGHT)
         I_Error(english_language ?
                 "R_DrawTLColumn: %i to %i at %i" :
                 "R_DrawTLColumn: %i к %i в %i",
@@ -215,7 +214,7 @@ void R_DrawTLColumn(void)
             tinttable[((*dest) << 8) +
                       dc_colormap[dc_source[(frac >> FRACBITS) & 127]]];
 
-        dest += SCREENWIDTH;
+        dest += screenwidth;
         frac += fracstep;
     }
     while (count--);
@@ -251,7 +250,7 @@ void R_DrawTranslatedColumn(void)
         return;
 
 #ifdef RANGECHECK
-    if ((unsigned) dc_x >= SCREENWIDTH || dc_yl < 0 || dc_yh >= SCREENHEIGHT)
+    if ((unsigned) dc_x >= screenwidth || dc_yl < 0 || dc_yh >= SCREENHEIGHT)
         I_Error(english_language ?
                 "R_DrawColumn: %i to %i at %i" :
                 "R_DrawColumn: %i к %i в %i",
@@ -266,7 +265,7 @@ void R_DrawTranslatedColumn(void)
     do
     {
         *dest = dc_colormap[dc_translation[dc_source[frac >> FRACBITS]]];
-        dest += SCREENWIDTH;
+        dest += screenwidth;
         frac += fracstep;
     }
     while (count--);
@@ -283,7 +282,7 @@ void R_DrawTranslatedTLColumn(void)
         return;
 
 #ifdef RANGECHECK
-    if ((unsigned) dc_x >= SCREENWIDTH || dc_yl < 0 || dc_yh >= SCREENHEIGHT)
+    if ((unsigned) dc_x >= screenwidth || dc_yl < 0 || dc_yh >= SCREENHEIGHT)
         I_Error(english_language ?
                 "R_DrawColumn: %i to %i at %i" :
                 "R_DrawColumn: %i к %i в %i",
@@ -301,7 +300,7 @@ void R_DrawTranslatedTLColumn(void)
                           +
                           dc_colormap[dc_translation
                                       [dc_source[frac >> FRACBITS]]]];
-        dest += SCREENWIDTH;
+        dest += screenwidth;
         frac += fracstep;
     }
     while (count--);
@@ -366,7 +365,7 @@ void R_DrawSpan(void)
     int count, spot;
 
 #ifdef RANGECHECK
-    if (ds_x2 < ds_x1 || ds_x1 < 0 || ds_x2 >= SCREENWIDTH
+    if (ds_x2 < ds_x1 || ds_x1 < 0 || ds_x2 >= screenwidth
         || (unsigned) ds_y > SCREENHEIGHT)
         I_Error(english_language ?
                 "R_DrawSpan: %i to %i at %i" :
@@ -399,7 +398,7 @@ void R_DrawSpanLow(void)
     int count, spot;
 
 #ifdef RANGECHECK
-    if (ds_x2 < ds_x1 || ds_x1 < 0 || ds_x2 >= SCREENWIDTH
+    if (ds_x2 < ds_x1 || ds_x1 < 0 || ds_x2 >= screenwidth
         || (unsigned) ds_y > SCREENHEIGHT)
         I_Error(english_language ?
                 "R_DrawSpan: %i to %i at %i" :
@@ -439,15 +438,15 @@ void R_InitBuffer(int width, int height)
 {
     int i;
 
-    viewwindowx = (SCREENWIDTH - width) >> 1;
+    viewwindowx = (screenwidth - width) >> 1;
     for (i = 0; i < width; i++)
         columnofs[i] = viewwindowx + i;
-    if (width == SCREENWIDTH)
+    if (width == screenwidth)
         viewwindowy = 0;
     else
         viewwindowy = (SCREENHEIGHT - SBARHEIGHT - height) >> 1;
     for (i = 0; i < height; i++)
-        ylookup[i] = I_VideoBuffer + (i + viewwindowy) * SCREENWIDTH;
+        ylookup[i] = I_VideoBuffer + (i + viewwindowy) * screenwidth;
 }
 
 
@@ -467,7 +466,7 @@ void R_DrawViewBorder(void)
     byte *src, *dest;
     int x, y;
 
-    if (scaledviewwidth == SCREENWIDTH)
+    if (scaledviewwidth == screenwidth)
         return;
 
     if (gamemode == shareware)
@@ -482,15 +481,15 @@ void R_DrawViewBorder(void)
 
     for (y = 0; y < SCREENHEIGHT - SBARHEIGHT; y++)
     {
-        for (x = 0; x < SCREENWIDTH / 64; x++)
+        for (x = 0; x < screenwidth / 64; x++)
         {
             memcpy(dest, src + ((y & 63) << 6), 64);
             dest += 64;
         }
-        if (SCREENWIDTH & 63)
+        if (screenwidth & 63)
         {
-            memcpy(dest, src + ((y & 63) << 6), SCREENWIDTH & 63);
-            dest += (SCREENWIDTH & 63);
+            memcpy(dest, src + ((y & 63) << 6), screenwidth & 63);
+            dest += (screenwidth & 63);
         }
     }
     for (x = (viewwindowx >> hires); x < ((viewwindowx >> hires) + (viewwidth >> hires)); x += 16)
@@ -533,7 +532,7 @@ void R_DrawTopBorder(void)
     byte *src, *dest;
     int x, y;
 
-    if (scaledviewwidth == SCREENWIDTH)
+    if (scaledviewwidth == screenwidth)
         return;
 
     if (gamemode == shareware)
@@ -548,15 +547,15 @@ void R_DrawTopBorder(void)
 
     for (y = 0; y < 30; y++)
     {
-        for (x = 0; x < SCREENWIDTH / 64; x++)
+        for (x = 0; x < screenwidth / 64; x++)
         {
             memcpy(dest, src + ((y & 63) << 6), 64);
             dest += 64;
         }
-        if (SCREENWIDTH & 63)
+        if (screenwidth & 63)
         {
-            memcpy(dest, src + ((y & 63) << 6), SCREENWIDTH & 63);
-            dest += (SCREENWIDTH & 63);
+            memcpy(dest, src + ((y & 63) << 6), screenwidth & 63);
+            dest += (screenwidth & 63);
         }
     }
     if ((viewwindowy >> hires) < 25)

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -206,7 +206,7 @@ typedef byte lighttable_t;      // this could be wider for >8 bit display
 
 #define	MAXVISPLANES	128
 // [JN] MAXOPENINGS увеличено в 4 раза
-#define	MAXOPENINGS		SCREENWIDTH*64*4
+#define	MAXOPENINGS		WIDESCREENWIDTH*64*4
 
 typedef struct
 {
@@ -216,10 +216,10 @@ typedef struct
     int special;
     int minx, maxx;
     unsigned int pad1;                // [crispy] hires / 32-bit integer math
-    unsigned int top[SCREENWIDTH];    // [crispy] hires / 32-bit integer math
+    unsigned int top[WIDESCREENWIDTH];// [crispy] hires / 32-bit integer math
     unsigned int pad2;                // [crispy] hires / 32-bit integer math
     unsigned int pad3;                // [crispy] hires / 32-bit integer math
-    unsigned int bottom[SCREENWIDTH]; // [crispy] hires / 32-bit integer math
+    unsigned int bottom[WIDESCREENWIDTH]; // [crispy] hires / 32-bit integer math
     unsigned int pad4;                // [crispy] hires / 32-bit integer math
 } visplane_t;
 
@@ -323,7 +323,7 @@ extern player_t *viewplayer;
 extern angle_t clipangle;
 
 extern int viewangletox[FINEANGLES / 2];
-extern angle_t xtoviewangle[SCREENWIDTH + 1];
+extern angle_t xtoviewangle[WIDESCREENWIDTH + 1];
 
 extern fixed_t rw_distance;
 extern angle_t rw_normalangle;
@@ -450,12 +450,12 @@ extern int skyflatnum;
 extern int*  lastopening; // [crispy] 32-bit integer math
   
 
-extern int floorclip[SCREENWIDTH];   // [crispy] 32-bit integer math
-extern int ceilingclip[SCREENWIDTH]; // [crispy] 32-bit integer math
+extern int floorclip[WIDESCREENWIDTH];   // [crispy] 32-bit integer math
+extern int ceilingclip[WIDESCREENWIDTH]; // [crispy] 32-bit integer math
 
 extern fixed_t* yslope;
 extern fixed_t yslopes[LOOKDIRS][SCREENHEIGHT];
-extern fixed_t distscale[SCREENWIDTH];
+extern fixed_t distscale[WIDESCREENWIDTH];
 
 void R_InitPlanes(void);
 void R_ClearPlanes(void);
@@ -489,7 +489,7 @@ extern int firstflat;
 extern int numflats;
 
 // [crispy] lookup table for horizontal screen coordinates
-extern int flipwidth[MAXWIDTH];
+extern int flipwidth[WIDEMAXWIDTH];
 
 extern int *flattranslation;    // for global animation
 extern int *texturetranslation; // for global animation
@@ -511,8 +511,8 @@ extern vissprite_t *vissprite_p;
 extern vissprite_t vsprsortedhead;
 
 // constant arrays used for psprite clipping and initializing clipping
-extern int negonearray[SCREENWIDTH];       // [crispy] 32-bit integer math
-extern int screenheightarray[SCREENWIDTH]; // [crispy] 32-bit integer math
+extern int negonearray[WIDESCREENWIDTH];       // [crispy] 32-bit integer math
+extern int screenheightarray[WIDESCREENWIDTH]; // [crispy] 32-bit integer math
 
 // vars for R_DrawMaskedColumn
 extern int*  mfloorclip;   // [crispy] 32-bit integer math

--- a/src/heretic/r_plane.c
+++ b/src/heretic/r_plane.c
@@ -56,8 +56,8 @@ int* lastopening;           // [crispy] 32-bit integer math
 // floorclip starts out SCREENHEIGHT
 // ceilingclip starts out -1
 //
-int  floorclip[SCREENWIDTH];   // [crispy] 32-bit integer math
-int  ceilingclip[SCREENWIDTH]; // [crispy] 32-bit integer math
+int  floorclip[WIDESCREENWIDTH];   // [crispy] 32-bit integer math
+int  ceilingclip[WIDESCREENWIDTH]; // [crispy] 32-bit integer math
 
 //
 // spanstart holds the start of a plane span
@@ -74,7 +74,7 @@ fixed_t planeheight;
 
 fixed_t* yslope;
 fixed_t yslopes[LOOKDIRS][SCREENHEIGHT];
-fixed_t distscale[SCREENWIDTH];
+fixed_t distscale[WIDESCREENWIDTH];
 fixed_t basexscale, baseyscale;
 
 fixed_t cachedheight[SCREENHEIGHT];
@@ -299,7 +299,7 @@ visplane_t *R_FindPlane(fixed_t height, int picnum,
     check->picnum = picnum;
     check->lightlevel = lightlevel;
     check->special = special;
-    check->minx = SCREENWIDTH;
+    check->minx = screenwidth;
     check->maxx = -1;
     memset(check->top, 0xff, sizeof(check->top));
     return (check);
@@ -487,7 +487,7 @@ void R_DrawPlanes(void)
                         return;
 
 #ifdef RANGECHECK
-                    if ((unsigned) dc_x >= SCREENWIDTH || dc_yl < 0
+                    if ((unsigned) dc_x >= screenwidth || dc_yl < 0
                         || dc_yh >= SCREENHEIGHT)
                         I_Error(english_language ?
                                 "R_DrawColumn: %i to %i at %i" :
@@ -502,7 +502,7 @@ void R_DrawPlanes(void)
                     do
                     {
                         *dest = dc_source[frac >> FRACBITS];
-                        dest += SCREENWIDTH;
+                        dest += screenwidth;
                         frac += fracstep;
                     }
                     while (count--);

--- a/src/heretic/r_things.c
+++ b/src/heretic/r_things.c
@@ -66,8 +66,8 @@ lighttable_t** fullbrights_ethereal;
 
 
 // constant arrays used for psprite clipping and initializing clipping
-int negonearray[SCREENWIDTH];       // [crispy] 32-bit integer math
-int screenheightarray[SCREENWIDTH]; // [crispy] 32-bit integer math
+int negonearray[WIDESCREENWIDTH];       // [crispy] 32-bit integer math
+int screenheightarray[WIDESCREENWIDTH]; // [crispy] 32-bit integer math
 
 /*
 ===============================================================================
@@ -295,7 +295,7 @@ void R_InitSprites(char **namelist)
 {
     int i;
 
-    for (i = 0; i < SCREENWIDTH; i++)
+    for (i = 0; i < screenwidth; i++)
     {
         negonearray[i] = -1;
     }
@@ -1099,15 +1099,7 @@ void R_DrawPSprite(pspdef_t * psp)
     vis->mobjflags = 0;
     vis->psprite = true;
     // [crispy] weapons drawn 1 pixel too high when player is idle
-#ifdef WIDESCREEN
-    // [JN] Wide screen: weapon positioning for HUD and non-HUD view
-    if (screenblocks <= 10)
-    vis->texturemid = (BASEYCENTER<<FRACBITS)+(FRACUNIT*26)+(FRACUNIT/4)-(psp_sy-spritetopoffset[lump]);
-    else
     vis->texturemid = (BASEYCENTER<<FRACBITS)+FRACUNIT/4-(psp_sy-spritetopoffset[lump]);
-#else
-    vis->texturemid = (BASEYCENTER<<FRACBITS)+FRACUNIT/4-(psp_sy-spritetopoffset[lump]);
-#endif
     if (viewheight == SCREENHEIGHT)
     {
         vis->texturemid -= PSpriteSY[players[consoleplayer].readyweapon];
@@ -1427,8 +1419,8 @@ void R_SortVisSprites(void)
 void R_DrawSprite(vissprite_t * spr)
 {
     drawseg_t *ds;
-    int clipbot[SCREENWIDTH]; // [crispy] 32-bit integer math
-    int cliptop[SCREENWIDTH]; // [crispy] 32-bit integer math
+    int clipbot[WIDESCREENWIDTH]; // [crispy] 32-bit integer math
+    int cliptop[WIDESCREENWIDTH]; // [crispy] 32-bit integer math
     int x, r1, r2;
     fixed_t scale, lowscale;
     int silhouette;

--- a/src/heretic/rd_lang.h
+++ b/src/heretic/rd_lang.h
@@ -441,8 +441,8 @@ extern char* txt_crosshair_off;
 #define TXT_CHEATARTIFACTSFAIL_RUS  "YTRJHHTRNYSQ DDJL"                     // НЕКОРРЕНТНЫЙ ВВОД
 #define TXT_CHEATWARP_RUS           "GTHTVTOTYBT YF EHJDTYM"                // ПЕРЕМЕЩЕНИЕ НА УРОВЕНЬ
 #define TXT_CHEATSCREENSHOT_RUS     "CYBVJR 'RHFYF"                         // СНИМОК ЭКРАНА
-#define TXT_CHEATCHICKENON_RUS      "GHTDHFOTYBT D WBGKTYRF"                // ПРЕВРАЩЕНИЕ В ЦИПЛЕНКА
-#define TXT_CHEATCHICKENOFF_RUS     "GHTDHFOTYBT D WBGKTYRF JNVTYTYJ"       // ПРЕВРАЩЕНИЕ В ЦИПЛЕНКА ОТМЕНЕНО
+#define TXT_CHEATCHICKENON_RUS      "GHTDHFOTYBT D WSGKTYRF"                // ПРЕВРАЩЕНИЕ В ЦЫПЛЕНКА
+#define TXT_CHEATCHICKENOFF_RUS     "GHTDHFOTYBT D WSGKTYRF JNVTYTYJ"       // ПРЕВРАЩЕНИЕ В ЦЫПЛЕНКА ОТМЕНЕНО
 #define TXT_CHEATMASSACRE_RUS       "DCT VJYCNHS EYBXNJ;TYS"                // ВСЕ МОНСТРЫ УНИЧТОЖЕНЫ
 #define TXT_CHEATIDDQD_RUS          "GSNFTIMCZ C[BNHBNM? NFR EVHB ;T!"      // ПЫТАЕШЬСЯ СХИТРИТЬ? ТАК УМРИ ЖЕ!
 #define TXT_CHEATIDKFA_RUS          ";EKBR< NS YT LJCNJBY CDJTUJ JHE;BZ"    // ЖУЛИК, ТЫ НЕ ДОСТОИН СВОЕГО ОРУЖИЯ

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -470,13 +470,13 @@ static void ShadeLine(int x, int y, int height, int shade)
     height <<= hires;
 
     shades = colormaps + 9 * 256 + shade * 2 * 256;
-    dest = I_VideoBuffer + y * SCREENWIDTH + x;
+    dest = I_VideoBuffer + y * screenwidth + x;
     while (height--)
     {
         if (hires)
            *(dest + 1) = *(shades + *dest);
         *(dest) = *(shades + *dest);
-        dest += SCREENWIDTH;
+        dest += screenwidth;
     }
 }
 
@@ -492,8 +492,8 @@ static void ShadeChain(void)
 
     for (i = 0; i < 16; i++)
     {
-        ShadeLine(277 + i + ORIGWIDTH_DELTA, 190, 10, i / 2);
-        ShadeLine(19 + i + ORIGWIDTH_DELTA, 190, 10, 7 - (i / 2));
+        ShadeLine(277 + i + wide_delta, 190, 10, i / 2);
+        ShadeLine(19 + i + wide_delta, 190, 10, 7 - (i / 2));
     }
 }
 
@@ -514,13 +514,19 @@ static void DrawSoundInfo(void)
     int x;
     int y;
     int xPos[7] = { 1, 75, 112, 156, 200, 230, 260 };
+    extern int snd_Channels;
 
     if (leveltime & 16)
     {
-		MN_DrTextA(DEH_String(english_language ?
-                              "*** SOUND DEBUG INFO ***" :
-                              "*** JNKFLJXYFZ BYAJHVFWBZ J PDERT ***"), // *** ОТЛАДОЧНАЯ ИНФОРМАЦИЯ О ЗВУКЕ ***
-                              xPos[0], 20);
+        if (english_language)
+        {
+            MN_DrTextSmallENG(DEH_String("*** SOUND DEBUG INFO ***"), xPos[0] + wide_delta, 20);
+        }
+        else
+        {
+            // *** ОТЛАДОЧНАЯ ИНФОРМАЦИЯ О ЗВУКЕ ***
+            MN_DrTextSmallRUS(DEH_String("*** JNKFLJXYFZ BYAJHVFWBZ J PDERT ***"), xPos[0] + wide_delta, 20);
+        }
     }
     S_GetChannelInfo(&s);
     if (s.channelCount == 0)
@@ -528,13 +534,13 @@ static void DrawSoundInfo(void)
         return;
     }
     x = 0;
-    MN_DrTextA(DEH_String(english_language ? "NAME" : "BVZ"), xPos[x++], 30);   // ИМЯ
-    MN_DrTextA(DEH_String(english_language ? "MO.T" : "VJ>N"), xPos[x++], 30);  // МО.Т
-    MN_DrTextA(DEH_String(english_language ? "MO.X" : "VJ>["), xPos[x++], 30);  // МО.Х
-    MN_DrTextA(DEH_String(english_language ? "MO.Y" : "VJ>E"), xPos[x++], 30);  // МО.У
-    MN_DrTextA(DEH_String(english_language ? "ID" : "YV"), xPos[x++], 30);      // НМ (НОМЕР)
-    MN_DrTextA(DEH_String(english_language ? "PRI" : "GHT"), xPos[x++], 30);    // ПРЕ
-    MN_DrTextA(DEH_String(english_language ? "DIST" : "LBCN"), xPos[x++], 30);  // ДИСТ
+    MN_DrTextA(DEH_String("NAME"), xPos[x++] + wide_delta, 30);
+    MN_DrTextA(DEH_String("MO.T"), xPos[x++] + wide_delta, 30);
+    MN_DrTextA(DEH_String("MO.X"), xPos[x++] + wide_delta, 30);
+    MN_DrTextA(DEH_String("MO.Y"), xPos[x++] + wide_delta, 30);
+    MN_DrTextA(DEH_String("ID"), xPos[x++] + wide_delta, 30);
+    MN_DrTextA(DEH_String("PRI"), xPos[x++] + wide_delta, 30);
+    MN_DrTextA(DEH_String("DIST"), xPos[x++] + wide_delta, 30);
     for (i = 0; i < s.channelCount; i++)
     {
         c = &s.chan[i];
@@ -542,24 +548,29 @@ static void DrawSoundInfo(void)
         y = 40 + i * 10;
         if (c->mo == NULL)
         {                       // Channel is unused
-            MN_DrTextA(DEH_String("------"), xPos[0], y);
+            // [JN] Draw only for 8 channes max, otherwise lines will be
+            // drawing beneath status bar and game will crash.
+            if (snd_Channels <= 8)
+            {
+                MN_DrTextA(DEH_String("------"), xPos[0] + wide_delta, y);
+            }
             continue;
         }
         M_snprintf(text, sizeof(text), "%s", c->name);
         M_ForceUppercase(text);
-        MN_DrTextA(text, xPos[x++], y);
+        MN_DrTextA(text, xPos[x++] + wide_delta, y);
         M_snprintf(text, sizeof(text), "%d", c->mo->type);
-        MN_DrTextA(text, xPos[x++], y);
+        MN_DrTextA(text, xPos[x++] + wide_delta, y);
         M_snprintf(text, sizeof(text), "%d", c->mo->x >> FRACBITS);
-        MN_DrTextA(text, xPos[x++], y);
+        MN_DrTextA(text, xPos[x++] + wide_delta, y);
         M_snprintf(text, sizeof(text), "%d", c->mo->y >> FRACBITS);
-        MN_DrTextA(text, xPos[x++], y);
+        MN_DrTextA(text, xPos[x++] + wide_delta, y);
         M_snprintf(text, sizeof(text), "%d", c->id);
-        MN_DrTextA(text, xPos[x++], y);
+        MN_DrTextA(text, xPos[x++] + wide_delta, y);
         M_snprintf(text, sizeof(text), "%d", c->priority);
-        MN_DrTextA(text, xPos[x++], y);
+        MN_DrTextA(text, xPos[x++] + wide_delta, y);
         M_snprintf(text, sizeof(text), "%d", c->distance);
-        MN_DrTextA(text, xPos[x++], y);
+        MN_DrTextA(text, xPos[x++] + wide_delta, y);
     }
     UpdateState |= I_FULLSCRN;
     BorderNeedRefresh = true;
@@ -619,6 +630,14 @@ void SB_Drawer(void)
     static char s[64];
     int f = real_fps;
     char fps [999];
+    boolean wide_4_3 = widescreen && screenblocks == 9;
+
+    // [JN] Draw extended skulls and stone border
+    if ((widescreen && screenblocks == 10) || (widescreen && automapactive))
+    {
+        V_DrawPatch(0, 147, W_CacheLumpName(DEH_String("WDBARLF"), PU_CACHE));
+        V_DrawPatch(344, 147, W_CacheLumpName(DEH_String("WDBARRT"), PU_CACHE));
+    }
 
     // [JN] Draw local time widget
     if (local_time)
@@ -635,15 +654,15 @@ void SB_Drawer(void)
                        local_time == 2 ? 269 :
                        local_time == 3 ? 293 :
                        local_time == 4 ? 281 : 0) 
-                       + (ORIGWIDTH_DELTA * 2), 13);
+                       + (wide_4_3 ? wide_delta : wide_delta*2), 13);
     }
 
     // [JN] Draw FPS widget
     if (show_fps)
     {
         sprintf (fps, "%d", f);
-        MN_DrTextC("FPS:", 279 + (ORIGWIDTH_DELTA * 2), 23);
-        MN_DrTextC(fps, 297 + (ORIGWIDTH_DELTA * 2), 23);   // [JN] fps digits
+        MN_DrTextC("FPS:", 279 + (wide_4_3 ? wide_delta : wide_delta*2), 23);
+        MN_DrTextC(fps, 297 + (wide_4_3 ? wide_delta : wide_delta*2), 23);   // [JN] fps digits
     }
 
     // Sound info debug stuff
@@ -664,76 +683,21 @@ void SB_Drawer(void)
                                                      cr[CR_GREEN2RED_HERETIC];
         }
 
-#ifdef WIDESCREEN
         if (crosshair_scale)
         {
-            V_DrawPatch(ORIGWIDTH/2, ((ORIGHEIGHT+4)/2),
-                W_CacheLumpName(DEH_String("XHAIR_1S"), PU_CACHE));
-        }
-        else
-        {
-            V_DrawPatchUnscaled(SCREENWIDTH/2, ((SCREENHEIGHT+8)/2),
-                W_CacheLumpName(DEH_String("XHAIR_1U"), PU_CACHE));
-        }
-#else
-        if (crosshair_scale)
-        {
-            V_DrawPatch(ORIGWIDTH/2,
+            V_DrawPatch(origwidth/2,
                 ((screenblocks <= 10) ? (ORIGHEIGHT-38)/2 : (ORIGHEIGHT+4)/2),
                 W_CacheLumpName(DEH_String("XHAIR_1S"), PU_CACHE));
         }
         else
         {
-            V_DrawPatchUnscaled(SCREENWIDTH/2,
+            V_DrawPatchUnscaled(screenwidth/2,
                 ((screenblocks <= 10) ? (SCREENHEIGHT-76)/2 : (SCREENHEIGHT+8)/2),
                 W_CacheLumpName(DEH_String("XHAIR_1U"), PU_CACHE));
         }
-#endif
 
         dp_translation = NULL;
     }
-
-#ifdef WIDESCREEN
-    if (screenblocks == 9 || screenblocks == 10 || automapactive)
-    {
-        SB_state = -1; // [JN] Always do full update
-        V_DrawPatch(0 + ORIGWIDTH_DELTA, 158, PatchBARBACK);
-
-        // [JN] Draw extended skulls and stone border
-        if (screenblocks == 9 || automapactive)
-        {
-            V_DrawPatch(0, 147, W_CacheLumpName(DEH_String("WDBARLF"), PU_CACHE));
-            V_DrawPatch(344, 147, W_CacheLumpName(DEH_String("WDBARRT"), PU_CACHE));
-        }
-        else
-        {
-            V_DrawPatch(24, 148, W_CacheLumpName(DEH_String("WDBATLF"), PU_CACHE));
-            V_DrawPatch(344, 147, W_CacheLumpName(DEH_String("WDBATRT"), PU_CACHE));            
-        }
-        oldhealth = -1;
-        DrawCommonBar();
-
-        if (!inventory)
-        {
-            // Main interface
-            V_DrawPatch(34 + ORIGWIDTH_DELTA, 160, 
-                        english_language ? PatchSTATBAR : PatchSTATBAR_RUS);
-            oldarti = 0;
-            oldammo = -1;
-            oldarmor = -1;
-            oldweapon = -1;
-            oldfrags = -9999;       //can't use -1, 'cuz of negative frags
-            oldlife = -1;
-            oldkeys = -1;
-            DrawMainBar();
-        }
-        else
-        {
-            V_DrawPatch(34 + ORIGWIDTH_DELTA, 160, PatchINVBAR);
-            DrawInventoryBar();
-        }
-}
-#endif
 
     if (viewheight == SCREENHEIGHT && !automapactive)
     {
@@ -745,7 +709,7 @@ void SB_Drawer(void)
     {
         if (SB_state == -1)
         {
-            V_DrawPatch(0 + ORIGWIDTH_DELTA, 158, PatchBARBACK);
+            V_DrawPatch(0 + wide_delta, 158, PatchBARBACK);
             oldhealth = -1;
         }
         DrawCommonBar();
@@ -754,7 +718,7 @@ void SB_Drawer(void)
             if (SB_state != 0)
             {
                 // Main interface
-                V_DrawPatch(34 + ORIGWIDTH_DELTA, 160, 
+                V_DrawPatch(34 + wide_delta, 160, 
                             english_language ? PatchSTATBAR : PatchSTATBAR_RUS);
                 oldarti = 0;
                 oldammo = -1;
@@ -771,7 +735,7 @@ void SB_Drawer(void)
         {
             if (SB_state != 1)
             {
-                V_DrawPatch(34 +ORIGWIDTH_DELTA, 160, PatchINVBAR);
+                V_DrawPatch(34 + wide_delta, 160, PatchINVBAR);
             }
             DrawInventoryBar();
             SB_state = 1;
@@ -783,9 +747,9 @@ void SB_Drawer(void)
     if ((screenblocks <= 10 || automapactive) && (players[consoleplayer].cheats & CF_GODMODE
     || (CPlayer->powers[pw_invulnerability] && !vanillaparm)))
     {
-        V_DrawPatch(16 + ORIGWIDTH_DELTA, 167,
+        V_DrawPatch(16 + wide_delta, 167,
                     W_CacheLumpName(DEH_String("GOD1"), PU_CACHE));
-        V_DrawPatch(287 + ORIGWIDTH_DELTA, 167,
+        V_DrawPatch(287 + wide_delta, 167,
                     W_CacheLumpName(DEH_String("GOD2"), PU_CACHE));
 
         SB_state = -1;
@@ -843,7 +807,7 @@ void SB_Drawer(void)
             || !(CPlayer->powers[pw_weaponlevel2] & 16))
         {
             frame = (leveltime / 3) & 15;
-            V_DrawPatch(300 + ORIGWIDTH_DELTA, 17, // [JN] Do not obstruct clock widget
+            V_DrawPatch(300 + wide_delta, 17, // [JN] Do not obstruct clock widget
                         W_CacheLumpNum(spinbooklump + frame, PU_CACHE));
             BorderTopRefresh = true;
             UpdateState |= I_MESSAGES;
@@ -854,6 +818,14 @@ void SB_Drawer(void)
             UpdateState |= I_MESSAGES;
         }
     }
+
+    // [JN] Wide screen: draw black borders in emulated 4:3 mode.
+    if ((widescreen && screenblocks == 9)
+    ||  (widescreen && screenblocks == 9 && automapactive))
+    {
+        V_DrawBlackBorders();
+    }
+
 /*
 		if(CPlayer->powers[pw_weaponlevel2] > BLINKTHRESHOLD
 			|| (CPlayer->powers[pw_weaponlevel2]&8))
@@ -924,8 +896,8 @@ void DrawCommonBar(void)
     int chainY;
     int healthPos;
 
-    V_DrawPatch(0 + ORIGWIDTH_DELTA, 148, PatchLTFCTOP);
-    V_DrawPatch(290 + ORIGWIDTH_DELTA, 148, PatchRTFCTOP);
+    V_DrawPatch(0 + wide_delta, 148, PatchLTFCTOP);
+    V_DrawPatch(290 + wide_delta, 148, PatchRTFCTOP);
 
     if (oldhealth != HealthMarker)
     {
@@ -942,11 +914,11 @@ void DrawCommonBar(void)
         healthPos = (healthPos * 256) / 100;
         chainY =
             (HealthMarker == CPlayer->mo->health) ? 191 : 191 + ChainWiggle;
-        V_DrawPatch(0 + ORIGWIDTH_DELTA, 190, PatchCHAINBACK);
-        V_DrawPatch(2 + (healthPos % 17) + ORIGWIDTH_DELTA, chainY, PatchCHAIN);
-        V_DrawPatch(17 + healthPos + ORIGWIDTH_DELTA, chainY, PatchLIFEGEM);
-        V_DrawPatch(0 + ORIGWIDTH_DELTA, 190, PatchLTFACE);
-        V_DrawPatch(276 + ORIGWIDTH_DELTA, 190, PatchRTFACE);
+        V_DrawPatch(0 + wide_delta, 190, PatchCHAINBACK);
+        V_DrawPatch(2 + (healthPos % 17) + wide_delta, chainY, PatchCHAIN);
+        V_DrawPatch(17 + healthPos + wide_delta, chainY, PatchLIFEGEM);
+        V_DrawPatch(0 + wide_delta, 190, PatchLTFACE);
+        V_DrawPatch(276 + wide_delta, 190, PatchRTFACE);
         ShadeChain();
         UpdateState |= I_STATBAR;
     }
@@ -966,11 +938,11 @@ void DrawMainBar(void)
     // Ready artifact
     if (ArtifactFlash)
     {
-        V_DrawPatch(180 + ORIGWIDTH_DELTA, 161, PatchBLACKSQ);
+        V_DrawPatch(180 + wide_delta, 161, PatchBLACKSQ);
 
         temp = W_GetNumForName(DEH_String("useartia")) + ArtifactFlash - 1;
 
-        V_DrawPatch(182 + ORIGWIDTH_DELTA, 161, W_CacheLumpNum(temp, PU_CACHE));
+        V_DrawPatch(182 + wide_delta, 161, W_CacheLumpNum(temp, PU_CACHE));
         ArtifactFlash--;
         oldarti = -1;           // so that the correct artifact fills in after the flash
         UpdateState |= I_STATBAR;
@@ -978,13 +950,13 @@ void DrawMainBar(void)
     else if (oldarti != CPlayer->readyArtifact
              || oldartiCount != CPlayer->inventory[inv_ptr].count)
     {
-        V_DrawPatch(180 + ORIGWIDTH_DELTA, 161, PatchBLACKSQ);
+        V_DrawPatch(180 + wide_delta, 161, PatchBLACKSQ);
         if (CPlayer->readyArtifact > 0)
         {
-            V_DrawPatch(179 + ORIGWIDTH_DELTA, 160,
+            V_DrawPatch(179 + wide_delta, 160,
                         W_CacheLumpName(DEH_String(patcharti[CPlayer->readyArtifact]),
                                         PU_CACHE));
-            DrSmallNumber(CPlayer->inventory[inv_ptr].count, 201 + ORIGWIDTH_DELTA, 182);
+            DrSmallNumber(CPlayer->inventory[inv_ptr].count, 201 + wide_delta, 182);
         }
         oldarti = CPlayer->readyArtifact;
         oldartiCount = CPlayer->inventory[inv_ptr].count;
@@ -1015,7 +987,7 @@ void DrawMainBar(void)
                 else
                 dp_translation = cr[CR_GOLD2GREEN_HERETIC];
             }
-            DrINumber(temp, 61 + ORIGWIDTH_DELTA, 170);
+            DrINumber(temp, 61 + wide_delta, 170);
             oldfrags = temp;
             UpdateState |= I_STATBAR;
         }
@@ -1041,7 +1013,7 @@ void DrawMainBar(void)
         // if (oldlife != temp)
         {
             oldlife = temp;
-            V_DrawPatch(57 + ORIGWIDTH_DELTA, 171, PatchARMCLEAR);
+            V_DrawPatch(57 + wide_delta, 171, PatchARMCLEAR);
 
             // [JN] Colored HUD: Health
             if (colored_hud && !vanillaparm)
@@ -1056,7 +1028,7 @@ void DrawMainBar(void)
                 dp_translation = cr[CR_GOLD2RED_HERETIC];
             }
 
-            DrINumber(temp, 61 + ORIGWIDTH_DELTA, 170);
+            DrINumber(temp, 61 + wide_delta, 170);
             UpdateState |= I_STATBAR;
         }
     }
@@ -1070,15 +1042,15 @@ void DrawMainBar(void)
         
         if (CPlayer->keys[key_yellow])
         {
-            V_DrawPatch(153 + ORIGWIDTH_DELTA, 164, W_CacheLumpName(DEH_String("ykeyicon"), PU_CACHE));
+            V_DrawPatch(153 + wide_delta, 164, W_CacheLumpName(DEH_String("ykeyicon"), PU_CACHE));
         }
         if (CPlayer->keys[key_green])
         {
-            V_DrawPatch(153 + ORIGWIDTH_DELTA, 172, W_CacheLumpName(DEH_String("gkeyicon"), PU_CACHE));
+            V_DrawPatch(153 + wide_delta, 172, W_CacheLumpName(DEH_String("gkeyicon"), PU_CACHE));
         }
         if (CPlayer->keys[key_blue])
         {
-            V_DrawPatch(153 + ORIGWIDTH_DELTA, 180, W_CacheLumpName(DEH_String("bkeyicon"), PU_CACHE));
+            V_DrawPatch(153 + wide_delta, 180, W_CacheLumpName(DEH_String("bkeyicon"), PU_CACHE));
         }
         oldkeys = playerkeys;
         UpdateState |= I_STATBAR;
@@ -1087,7 +1059,7 @@ void DrawMainBar(void)
     temp = CPlayer->ammo[wpnlev1info[CPlayer->readyweapon].ammo];
     if (oldammo != temp || oldweapon != CPlayer->readyweapon)
     {
-        V_DrawPatch(108 + ORIGWIDTH_DELTA, 161, PatchBLACKSQ);
+        V_DrawPatch(108 + wide_delta, 161, PatchBLACKSQ);
         if (temp && CPlayer->readyweapon > 0 && CPlayer->readyweapon < 7)
         {
             // [JN] Colored HUD: Ammo
@@ -1106,8 +1078,8 @@ void DrawMainBar(void)
                 dp_translation = cr[CR_GOLD2BLUE_HERETIC];
             }
             
-            DrINumber(temp, 109 + ORIGWIDTH_DELTA, 162);
-            V_DrawPatch(111 + ORIGWIDTH_DELTA, 172,
+            DrINumber(temp, 109 + wide_delta, 162);
+            V_DrawPatch(111 + wide_delta, 172,
                         W_CacheLumpName(DEH_String(ammopic[CPlayer->readyweapon - 1]),
                                         PU_CACHE));
         }
@@ -1120,7 +1092,7 @@ void DrawMainBar(void)
     // [JN] Always update armor value, needed for colored HUD
     // if (oldarmor != CPlayer->armorpoints)
     {
-        V_DrawPatch(224 + ORIGWIDTH_DELTA, 171, PatchARMCLEAR);
+        V_DrawPatch(224 + wide_delta, 171, PatchARMCLEAR);
 
         // [JN] Colored HUD: Armor
         if (colored_hud && !vanillaparm)
@@ -1135,7 +1107,7 @@ void DrawMainBar(void)
             dp_translation = cr[CR_GOLD2RED_HERETIC];
         }
 
-        DrINumber(CPlayer->armorpoints, 228 + ORIGWIDTH_DELTA, 170);
+        DrINumber(CPlayer->armorpoints, 228 + wide_delta, 170);
         oldarmor = CPlayer->armorpoints;
         UpdateState |= I_STATBAR;
     }
@@ -1155,7 +1127,7 @@ void DrawInventoryBar(void)
 
     x = inv_ptr - curpos;
     UpdateState |= I_STATBAR;
-    V_DrawPatch(34 + ORIGWIDTH_DELTA, 160, PatchINVBAR);
+    V_DrawPatch(34 + wide_delta, 160, PatchINVBAR);
     for (i = 0; i < 7; i++)
     {
         //V_DrawPatch(50+i*31, 160, W_CacheLumpName("ARTIBOX", PU_CACHE));
@@ -1164,19 +1136,19 @@ void DrawInventoryBar(void)
         {
             patch = DEH_String(patcharti[CPlayer->inventory[x + i].type]);
 
-            V_DrawPatch(50 + i * 31 + ORIGWIDTH_DELTA, 160, W_CacheLumpName(patch, PU_CACHE));
-            DrSmallNumber(CPlayer->inventory[x + i].count, 69 + i * 31 + ORIGWIDTH_DELTA, 182);
+            V_DrawPatch(50 + i * 31 + wide_delta, 160, W_CacheLumpName(patch, PU_CACHE));
+            DrSmallNumber(CPlayer->inventory[x + i].count, 69 + i * 31 + wide_delta, 182);
         }
     }
-    V_DrawPatch(50 + curpos * 31 + ORIGWIDTH_DELTA, 189, PatchSELECTBOX);
+    V_DrawPatch(50 + curpos * 31 + wide_delta, 189, PatchSELECTBOX);
     if (x != 0)
     {
-        V_DrawPatch(38 + ORIGWIDTH_DELTA, 159, !(leveltime & 4) ? PatchINVLFGEM1 :
+        V_DrawPatch(38 + wide_delta, 159, !(leveltime & 4) ? PatchINVLFGEM1 :
                     PatchINVLFGEM2);
     }
     if (CPlayer->inventorySlotNum - x > 7)
     {
-        V_DrawPatch(269 + ORIGWIDTH_DELTA, 159, !(leveltime & 4) ?
+        V_DrawPatch(269 + wide_delta, 159, !(leveltime & 4) ?
                     PatchINVRTGEM1 : PatchINVRTGEM2);
     }
 }
@@ -1242,7 +1214,7 @@ void DrawFullScreenStuff(void)
             dp_translation = cr[CR_GREEN2BLUE_HERETIC];
         }
 
-        DrBNumber(fs_ammo, 274 + (ORIGWIDTH_DELTA * 2), 176);
+        DrBNumber(fs_ammo, 274 + (wide_delta * 2), 176);
     }
 
     if (deathmatch)
@@ -1272,16 +1244,16 @@ void DrawFullScreenStuff(void)
                 dp_translation = NULL;
             }
 
-            DrBNumber(temp, 173 + (ORIGWIDTH_DELTA * 2), 176);
+            DrBNumber(temp, 173 + (wide_delta * 2), 176);
         }
         
         // [JN] Always draw keys in Deathmatch, but only if player alive,
         // and not while opened inventory. Just as visual reminder.
         if (CPlayer->mo->health > 0 && !inventory)
         {
-            V_DrawShadowedPatch(219 + (ORIGWIDTH_DELTA * 2), 174, W_CacheLumpName(DEH_String("ykeyicon"), PU_CACHE));
-            V_DrawShadowedPatch(219 + (ORIGWIDTH_DELTA * 2), 182, W_CacheLumpName(DEH_String("gkeyicon"), PU_CACHE));
-            V_DrawShadowedPatch(219 + (ORIGWIDTH_DELTA * 2), 190, W_CacheLumpName(DEH_String("bkeyicon"), PU_CACHE));
+            V_DrawShadowedPatch(219 + (wide_delta * 2), 174, W_CacheLumpName(DEH_String("ykeyicon"), PU_CACHE));
+            V_DrawShadowedPatch(219 + (wide_delta * 2), 182, W_CacheLumpName(DEH_String("gkeyicon"), PU_CACHE));
+            V_DrawShadowedPatch(219 + (wide_delta * 2), 190, W_CacheLumpName(DEH_String("bkeyicon"), PU_CACHE));
         }
     }
     if (!inventory)
@@ -1316,11 +1288,11 @@ void DrawFullScreenStuff(void)
         if (!deathmatch)
         {
             if (CPlayer->keys[key_yellow])
-            V_DrawShadowedPatch(219 + (ORIGWIDTH_DELTA * 2), 174, W_CacheLumpName(DEH_String("ykeyicon"), PU_CACHE));
+            V_DrawShadowedPatch(219 + (wide_delta * 2), 174, W_CacheLumpName(DEH_String("ykeyicon"), PU_CACHE));
             if (CPlayer->keys[key_green])
-            V_DrawShadowedPatch(219 + (ORIGWIDTH_DELTA * 2), 182, W_CacheLumpName(DEH_String("gkeyicon"), PU_CACHE));
+            V_DrawShadowedPatch(219 + (wide_delta * 2), 182, W_CacheLumpName(DEH_String("gkeyicon"), PU_CACHE));
             if (CPlayer->keys[key_blue])
-            V_DrawShadowedPatch(219 + (ORIGWIDTH_DELTA * 2), 190, W_CacheLumpName(DEH_String("bkeyicon"), PU_CACHE));
+            V_DrawShadowedPatch(219 + (wide_delta * 2), 190, W_CacheLumpName(DEH_String("bkeyicon"), PU_CACHE));
         }
 
         if (CPlayer->readyArtifact > 0)
@@ -1328,8 +1300,8 @@ void DrawFullScreenStuff(void)
             patch = DEH_String(patcharti[CPlayer->readyArtifact]);
             
             // [JN] Draw Artifacts
-            V_DrawShadowedPatch(238 + (ORIGWIDTH_DELTA * 2), 170, W_CacheLumpName(patch, PU_CACHE));
-            DrSmallNumber(CPlayer->inventory[inv_ptr].count, 259 + (ORIGWIDTH_DELTA * 2), 191);
+            V_DrawShadowedPatch(238 + (wide_delta * 2), 170, W_CacheLumpName(patch, PU_CACHE));
+            DrSmallNumber(CPlayer->inventory[inv_ptr].count, 259 + (wide_delta * 2), 191);
         }
 
         if (CPlayer->armorpoints > 0)
@@ -1363,27 +1335,27 @@ void DrawFullScreenStuff(void)
         x = inv_ptr - curpos;
         for (i = 0; i < 7; i++)
         {
-            V_DrawTLPatch(50 + i * 31 + ORIGWIDTH_DELTA, 168,
+            V_DrawTLPatch(50 + i * 31 + wide_delta, 168,
                           W_CacheLumpName(DEH_String("ARTIBOX"), PU_CACHE));
             if (CPlayer->inventorySlotNum > x + i
                 && CPlayer->inventory[x + i].type != arti_none)
             {
                 patch = DEH_String(patcharti[CPlayer->inventory[x + i].type]);
-                V_DrawPatch(50 + i * 31 + ORIGWIDTH_DELTA, 168,
+                V_DrawPatch(50 + i * 31 + wide_delta, 168,
                             W_CacheLumpName(patch, PU_CACHE));
-                DrSmallNumber(CPlayer->inventory[x + i].count, 69 + i * 31 + ORIGWIDTH_DELTA,
+                DrSmallNumber(CPlayer->inventory[x + i].count, 69 + i * 31 + wide_delta,
                               190);
             }
         }
-        V_DrawPatch(50 + curpos * 31 + ORIGWIDTH_DELTA, 197, PatchSELECTBOX);
+        V_DrawPatch(50 + curpos * 31 + wide_delta, 197, PatchSELECTBOX);
         if (x != 0)
         {
-            V_DrawPatch(38 + ORIGWIDTH_DELTA, 167, !(leveltime & 4) ? PatchINVLFGEM1 :
+            V_DrawPatch(38 + wide_delta, 167, !(leveltime & 4) ? PatchINVLFGEM1 :
                         PatchINVLFGEM2);
         }
         if (CPlayer->inventorySlotNum - x > 7)
         {
-            V_DrawPatch(269 + ORIGWIDTH_DELTA, 167, !(leveltime & 4) ?
+            V_DrawPatch(269 + wide_delta, 167, !(leveltime & 4) ?
                         PatchINVRTGEM1 : PatchINVRTGEM2);
         }
     }
@@ -1543,10 +1515,6 @@ static void CheatKeysFunc(player_t * player, Cheat_t * cheat)
 
 static void CheatSoundFunc(player_t * player, Cheat_t * cheat)
 {
-    return; 
-
-    // [JN] TODO - crashing :O
-    /*
     DebugSound = !DebugSound;
     if (DebugSound)
     {
@@ -1556,7 +1524,6 @@ static void CheatSoundFunc(player_t * player, Cheat_t * cheat)
     {
         P_SetMessage(player, DEH_String(txt_cheatsoundoff), false);
     }
-    */
 }
 
 static void CheatTickerFunc(player_t * player, Cheat_t * cheat)

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -1137,13 +1137,14 @@ void V_CopyScaledBuffer(byte *dest, byte *src, size_t size)
 
     for (k = 0; k < size; k++)
     {
-        const int l = k / SRCWIDTH; // current line in the source screen
-        const int p = k - l * SRCWIDTH; // current pixel in this line
+        const int l = k / ORIGWIDTH; // current line in the source screen
+        const int p = k - l * ORIGWIDTH; // current pixel in this line
         for (i = 0; i <= hires; i++)
         {
             for (j = 0; j <= hires; j++)
             {
-                *(dest + (p << hires) + ((l << hires) + i) * screenwidth + j + (ORIGWIDTH_DELTA << hires)) = *(src + k);
+                *(dest + (p << hires) + ((l << hires) + i) * screenwidth + j 
+                       + (wide_delta << hires)) = *(src + k);
             }
         }
     }
@@ -1151,7 +1152,7 @@ void V_CopyScaledBuffer(byte *dest, byte *src, size_t size)
  
 void V_DrawRawScreen(byte *raw)
 {
-    V_CopyScaledBuffer(dest_screen, raw, SRCWIDTH * ORIGHEIGHT);
+    V_CopyScaledBuffer(dest_screen, raw, ORIGWIDTH * ORIGHEIGHT);
 }
 
 //


### PR DESCRIPTION
This includes:
* Consolidated wide and 4:3 code into one executable.
* Minimal screen size `9` emulating 4:3 mode.
* Cheat code `NOISE` working again.
* Fixed incorrect numerical representation of screen size slider in 4:3 mode.
* Fixed typo in Russian "Превращение в ц**ы**пленка".
* Fixes #154.