### PR TITLE
Rework of GUS patches loading

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -238,9 +238,6 @@ static char *steam_install_subdirs[] =
     "steamapps\\common\\Strife",
 };
 
-#define STEAM_BFG_GUS_PATCHES \
-    "steamapps\\common\\DOOM 3 BFG Edition\\base\\classicmusic\\instruments"
-
 static char *GetRegistryString(registry_value_t *reg_val)
 {
     HKEY key;
@@ -378,50 +375,6 @@ static void CheckSteamEdition(void)
 
     free(install_path);
 }
-
-// The BFG edition ships with a full set of GUS patches. If we find them,
-// we can autoconfigure to use them.
-// [JN] Function disabled. GUS patches now included in release package.
-
-/*
-static void CheckSteamGUSPatches(void)
-{
-    const char *current_path;
-    char *install_path;
-    char *patch_path;
-    int len;
-
-    // Already configured? Don't stomp on the user's choices.
-    current_path = M_GetStringVariable("gus_patches_path");
-    if (current_path != NULL && strlen(current_path) > 0)
-    {
-        return;
-    }
-
-    install_path = GetRegistryString(&steam_install_location);
-
-    if (install_path == NULL)
-    {
-        return;
-    }
-
-    len = strlen(install_path) + strlen(STEAM_BFG_GUS_PATCHES) + 20;
-    patch_path = malloc(len);
-    M_snprintf(patch_path, len, "%s\\%s\\ACBASS.PAT",
-               install_path, STEAM_BFG_GUS_PATCHES);
-
-    // Does acbass.pat exist? If so, then set gus_patches_path.
-    if (M_FileExists(patch_path))
-    {
-        M_snprintf(patch_path, len, "%s\\%s",
-                   install_path, STEAM_BFG_GUS_PATCHES);
-        M_SetVariable("gus_patches_path", patch_path);
-    }
-
-    free(patch_path);
-    free(install_path);
-}
-*/
 
 // Default install directories for DOS Doom
 
@@ -736,11 +689,6 @@ static void BuildIWADDirList(void)
     CheckInstallRootPaths();
     CheckSteamEdition();
     CheckDOSDefaults();
-
-    // Check for GUS patches installed with the BFG edition!
-    // [JN] Disable checking, GUS patches now included in release package.
-
-    // CheckSteamGUSPatches();
 
 #else
     AddXdgDirs();

--- a/src/gusconf.h
+++ b/src/gusconf.h
@@ -23,7 +23,7 @@
 
 #include "doomtype.h"
 
-extern char *gus_patches_path;
+extern char *gus_patch_path;
 extern int gus_ram_kb;
 
 boolean GUS_WriteConfig(char *path);

--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -445,8 +445,6 @@ void I_BindSoundVariables(void)
     // extern int use_libsamplerate;
     extern float libsamplerate_scale;
 
-    gus_patches_path = RD_M_FindInternalResource("gus_patches");
-
     M_BindIntVariable("snd_musicdevice",         &snd_musicdevice);
     M_BindIntVariable("snd_sfxdevice",           &snd_sfxdevice);
     M_BindIntVariable("snd_maxslicetime_ms",     &snd_maxslicetime_ms);
@@ -459,7 +457,7 @@ void I_BindSoundVariables(void)
     M_BindIntVariable("mute_inactive_window",    &mute_inactive_window);
 
     M_BindStringVariable("timidity_cfg_path",    &timidity_cfg_path);
-    M_BindStringVariable("gus_patches_path",     &gus_patches_path);
+    M_BindStringVariable("gus_patch_path",     &gus_patch_path);
     M_BindIntVariable("gus_ram_kb",              &gus_ram_kb);
 
 #ifdef FEATURE_SOUND

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1106,7 +1106,7 @@ static default_t extra_defaults_list[] =
     // mode.
     //
 
-    CONFIG_VARIABLE_STRING(gus_patches_path),
+    CONFIG_VARIABLE_STRING(gus_patch_path),
 
     //!
     // Number of kilobytes of RAM to use in GUS emulation mode. Valid

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -72,7 +72,7 @@ static int show_talk = 0;
 static float libsamplerate_scale = 0.65;
 
 static char *timidity_cfg_path = NULL;
-static char *gus_patches_path = "base/gus_patches";
+static char *gus_patch_path = "";
 static int gus_ram_kb = 1024;
 
 static int snd_oplmode;
@@ -211,7 +211,7 @@ void ConfigSound(void)
         TXT_NewConditional(&snd_musicdevice, SNDDEVICE_GUS,
             TXT_NewHorizBox(
                 TXT_NewStrut(4, 0),
-                TXT_NewFileSelector(&gus_patches_path, 34, english_language ?
+                TXT_NewFileSelector(&gus_patch_path, 34, english_language ?
                                     "Select directory containing GUS patches" :
                                     "“кажите путь к патчам GUS",
                                     TXT_DIRECTORY),
@@ -242,7 +242,7 @@ void ConfigSound(void)
                         "Mute inactive window" :
                         "‡вук в неактивном окне",
                         &mute_inactive_window),
-                         
+
         NULL);
 
     //
@@ -273,7 +273,7 @@ void BindSoundVariables(void)
     M_BindFloatVariable("libsamplerate_scale",    &libsamplerate_scale);
 
     M_BindIntVariable("gus_ram_kb",               &gus_ram_kb);
-    M_BindStringVariable("gus_patches_path",      &gus_patches_path);
+    M_BindStringVariable("gus_patch_path",      &gus_patch_path);
     M_BindStringVariable("timidity_cfg_path",     &timidity_cfg_path);
 
     M_BindIntVariable("snd_maxslicetime_ms",      &snd_maxslicetime_ms);
@@ -293,7 +293,6 @@ void BindSoundVariables(void)
     }
 
     timidity_cfg_path = M_StringDuplicate("");
-    gus_patches_path = RD_M_FindInternalResource("gus_patches");
 
     // All versions of Heretic and Hexen did pitch-shifting.
     // Most versions of Doom did not and Strife never did.


### PR DESCRIPTION
Added `-gus_patches <path>` command-line parameter to specify GUS patches.
Config variable `gus_patches_path` renamed to `gus_patch_path` and no longer require to be set.
If no GUS patches provided by the user via config variable or command line parameter then bundled GUS patches will be used.