### PR TITLE
Hexen: Bumped max size of save file path to 261 (Windows MAX_PATH + 1)

### DIFF
--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -115,6 +115,9 @@ typedef uint8_t byte;
 
 #endif
 
+// [Dasperal] Use Windows MAX_PATH + 1 as max path length for RD
+#define RD_MAX_PATH 261
+
 #define arrlen(array) (sizeof(array) / sizeof(*array))
 
 #endif

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -1527,7 +1527,7 @@ static boolean ReadDescriptionForSlot(int slot, char *description)
 {
     FILE *fp;
     boolean found;
-    char name[100];
+    char name[RD_MAX_PATH];
     char versionText[HXS_VERSION_TEXT_LENGTH];
 
     M_snprintf(name, sizeof(name), "%shexen-save-%d.sav", SavePath, slot);

--- a/src/hexen/sc_man.c
+++ b/src/hexen/sc_man.c
@@ -78,7 +78,7 @@ static boolean AlreadyGot = false;
 
 void SC_Open(char *name)
 {
-    char fileName[128];
+    char fileName[RD_MAX_PATH];
 
     if (sc_FileScripts == true)
     {

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -1925,7 +1925,7 @@ static void StreamOut_floorWaggle_t(floorWaggle_t *str)
 
 void SV_SaveGame(int slot, char *description)
 {
-    char fileName[100];
+    char fileName[RD_MAX_PATH];
     char versionText[HXS_VERSION_TEXT_LENGTH];
     unsigned int i;
 
@@ -1985,7 +1985,7 @@ void SV_SaveGame(int slot, char *description)
 
 void SV_SaveMap(boolean savePlayers)
 {
-    char fileName[100];
+    char fileName[RD_MAX_PATH];
 
     SavingPlayers = savePlayers;
 
@@ -2026,7 +2026,7 @@ void SV_SaveMap(boolean savePlayers)
 void SV_LoadGame(int slot)
 {
     int i;
-    char fileName[100];
+    char fileName[RD_MAX_PATH];
     char version_text[HXS_VERSION_TEXT_LENGTH];
     player_t playerBackup[MAXPLAYERS];
     mobj_t *mobj;
@@ -2145,7 +2145,7 @@ void SV_MapTeleport(int map, int position)
 {
     int i;
     int j;
-    char fileName[100];
+    char fileName[RD_MAX_PATH];
     player_t playerBackup[MAXPLAYERS];
     mobj_t *targetPlayerMobj;
     mobj_t *mobj;
@@ -2335,7 +2335,7 @@ int SV_GetRebornSlot(void)
 
 boolean SV_RebornSlotAvailable(void)
 {
-    char fileName[100];
+    char fileName[RD_MAX_PATH];
 
     M_snprintf(fileName, sizeof(fileName), "%shexen-save-%d.sav", SavePath, REBORN_SLOT);
     return ExistingFile(fileName);
@@ -2349,7 +2349,7 @@ boolean SV_RebornSlotAvailable(void)
 
 void SV_LoadMap(void)
 {
-    char fileName[100];
+    char fileName[RD_MAX_PATH];
 
     // Load a base level
     G_InitNew(gameskill, gameepisode, gamemap);
@@ -3214,7 +3214,7 @@ static void AssertSegment(gameArchiveSegment_t segType)
 static void ClearSaveSlot(int slot)
 {
     int i;
-    char fileName[100];
+    char fileName[RD_MAX_PATH];
 
     for (i = 0; i < MAX_MAPS; i++)
     {
@@ -3237,8 +3237,8 @@ static void ClearSaveSlot(int slot)
 static void CopySaveSlot(int sourceSlot, int destSlot)
 {
     int i;
-    char sourceName[100];
-    char destName[100];
+    char sourceName[RD_MAX_PATH];
+    char destName[RD_MAX_PATH];
 
     for (i = 0; i < MAX_MAPS; i++)
     {

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -35,6 +35,7 @@
 #include "doomtype.h"
 #include "i_system.h"
 #include "m_argv.h"
+#include "m_misc.h"
 
 // [JN] Vanilla game mode available for all three games in RD
 boolean vanillaparm;
@@ -74,6 +75,24 @@ void RD_CreateWindowsConsole (void)
     wcscpy(cfi.FaceName, L"Consolas");
     SetCurrentConsoleFontEx(GetStdHandle(STD_OUTPUT_HANDLE), FALSE, &cfi);
 }
+
+void M_SetExeDir(void)
+{
+    TCHAR dirname[MAX_PATH + 1];
+    DWORD dirname_len;
+    TCHAR *fp = NULL;
+
+    memset(dirname, 0, sizeof(dirname));
+    dirname_len = GetModuleFileName(NULL, dirname, MAX_PATH);
+    fp = &dirname[dirname_len];
+    while (dirname <= fp && *fp != DIR_SEPARATOR)
+    {
+        fp--;
+    }
+    *(fp + 1) = '\0';
+
+    exedir = M_StringDuplicate(dirname);
+}
 #endif
 
 
@@ -93,13 +112,14 @@ int main(int argc, char **argv)
     myargc = argc;
     myargv = argv;
 
-    M_SetExeDir();
     M_FindResponseFile();
 
     // Check for -devparm being activated
     devparm = M_CheckParm ("-devparm");
 
 #ifdef _WIN32
+    M_SetExeDir();
+
     // [JN] Create a console output on Windows for devparm mode.
     if (devparm)
     {

--- a/src/m_argv.c
+++ b/src/m_argv.c
@@ -271,12 +271,3 @@ char *M_GetExecutableName(void)
 }
 
 char *exedir = NULL;
-
-void M_SetExeDir(void)
-{
-    char *dirname;
-
-    dirname = M_DirName(myargv[0]);
-    exedir = M_StringJoin(dirname, DIR_SEPARATOR_S, NULL);
-    free(dirname);
-}

--- a/src/m_argv.h
+++ b/src/m_argv.h
@@ -32,7 +32,6 @@ extern  char**	myargv;
 
 // [Dasperal] exedir from chocolate
 extern char *exedir;
-void M_SetExeDir(void);
 
 // Returns the position of the given parameter
 // in the arg list (0 if not found).


### PR DESCRIPTION
Fixes #254 

Also changed the way the path to the executable is obtained. It is now done thru WinAPI instead of argv[0] because argv[0] degrades to `current directory` if the PATH environment variable contains path to RD