### PR TITLE
Fix keybinds system

### DIFF
--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -635,6 +635,7 @@ static MenuItem_t Bindings2Items[] = {
     {ITT_TITLE,   "ACTION",          "LTQCNDBT",               NULL,               0},
     {ITT_EFUNC,   "FIRE/ATTACK",     "FNFRF/CNHTKM,F",         BK_StartBindingKey, bk_fire},        // Атака/стрельба
     {ITT_EFUNC,   "USE",             "BCGJKMPJDFNM",           BK_StartBindingKey, bk_use},         // Использовать
+    {ITT_EFUNC,   "JUMP",            "GHS;JR",                 BK_StartBindingKey, bk_jump},        //Прыжок
     {ITT_TITLE,   "WEAPONS",         "JHE;BT",                 NULL,               0},       // Оружие
     {ITT_EFUNC,   "WEAPON 1",        "JHE;BT 1",               BK_StartBindingKey, bk_weapon_1},    // Оружие 1
     {ITT_EFUNC,   "WEAPON 2",        "JHE;BT 2",               BK_StartBindingKey, bk_weapon_2},    // Оружие 2
@@ -642,7 +643,6 @@ static MenuItem_t Bindings2Items[] = {
     {ITT_EFUNC,   "WEAPON 4",        "JHE;BT 4",               BK_StartBindingKey, bk_weapon_4},    // Оружие 4
     {ITT_EFUNC,   "PREVIOUS WEAPON", "GHTLSLEOTT JHE;BT",      BK_StartBindingKey, bk_weapon_prev}, // Предыдущее оружие
     {ITT_EFUNC,   "NEXT WEAPON",     "CKTLE.OTT JHE;BT",       BK_StartBindingKey, bk_weapon_next}, // Следующее оружие
-    {ITT_EMPTY,   NULL,              NULL,                     NULL,               0},
     {ITT_EMPTY,   NULL,              NULL,                     NULL,               0},
     {ITT_EMPTY,   NULL,              NULL,                     NULL,               0},
     {ITT_SETMENU, "NEXT PAGE...",    "CKTLE.OFZ CNHFYBWF>>>",  &Bindings3Menu,     0},              // Cледующая страница...

--- a/src/rd_keybinds.c
+++ b/src/rd_keybinds.c
@@ -458,6 +458,25 @@ static void AddBind(bound_key_t boundKey, device_t device, int key)
 
 void BK_BindKey(event_t* event)
 {
+    // [Dasperal] Prohibit binding of some keyboard keys and gamepad menu key
+    if((event->type == ev_keydown
+    && (event->data1 == KEY_F1
+    || event->data1 == KEY_F2
+    || event->data1 == KEY_F3
+    || event->data1 == KEY_F4
+    || event->data1 == KEY_F5
+    || event->data1 == KEY_F7
+    || event->data1 == KEY_F8
+    || event->data1 == KEY_F10
+    || event->data1 == KEY_F11
+    || event->data1 == KEY_EQUALS
+    || event->data1 == KEY_MINUS
+    || event->data1 == KEY_PAUSE))
+    || (event->type == ev_controller_keydown && event->data1 == CONTROLLER_START))
+    {
+        return;
+    }
+
     isBinding = false;
 
     if(!BK_isKeyDown(event, bk_menu_activate))

--- a/src/rd_keybinds.c
+++ b/src/rd_keybinds.c
@@ -409,12 +409,54 @@ void BK_StartBindingKey(bound_key_t key)
     keyToBind = key;
 }
 
+// -----------------------------------------------------------------------------
+// RemoveKeyFromBinds
+// Removes given key of device from all bound_keys
+// -----------------------------------------------------------------------------
+void RemoveKeyFromBinds(device_t device, int key)
+{
+    bind_descriptor_t *prevDescriptor, *tmp;
+
+    for(int i = bk_forward; i < bk__serializable; ++i)
+    {
+        if(bind_descriptor[i] == NULL)
+            continue;
+
+        if(bind_descriptor[i]->device == device && bind_descriptor[i]->key == key)
+        {
+            tmp = bind_descriptor[i];
+            bind_descriptor[i] = bind_descriptor[i]->next;
+            free(tmp);
+            continue;
+        }
+
+        prevDescriptor = bind_descriptor[i];
+        tmp = prevDescriptor->next;
+        while(tmp)
+        {
+            if(tmp->device == device && tmp->key == key)
+            {
+                prevDescriptor->next = tmp->next;
+                free(tmp);
+                break; // from while loop
+            }
+            else
+            {
+                prevDescriptor = tmp;
+                tmp = prevDescriptor->next;
+            }
+        }
+    }
+}
+
 static void AddBind(bound_key_t boundKey, device_t device, int key)
 {
     bind_descriptor_t* bind = bind_descriptor[boundKey];
 
     if(bind == NULL)
     {
+        if(bindClearEnabled)
+            RemoveKeyFromBinds(device, key);
         bind = malloc(sizeof(bind_descriptor));
         bind->next = NULL;
         bind->device = device;
@@ -447,6 +489,8 @@ static void AddBind(bound_key_t boundKey, device_t device, int key)
         }
 
         // Add new bind
+        if(bindClearEnabled)
+            RemoveKeyFromBinds(device, key);
         bind = malloc(sizeof(bind_descriptor));
         bind->next = NULL;
         bind->device = device;
@@ -505,6 +549,8 @@ void BK_ClearBinds(bound_key_t key)
 
 void BK_AddBindingsToSystemKeys()
 {
+    bindClearEnabled = false;
+
     // Keyboard
     AddBind(bk_left,  keyboard, KEY_LEFTARROW);
     AddBind(bk_right, keyboard, KEY_RIGHTARROW);
@@ -560,10 +606,14 @@ void BK_AddBindingsToSystemKeys()
 
     AddBind(bk_confirm, controller, CONTROLLER_A);
     AddBind(bk_abort,   controller, CONTROLLER_B);
+
+    bindClearEnabled = true;
 };
 
 void BK_ApplyDefaultBindings()
 {
+    bindClearEnabled = false;
+
     // Keyboard
     AddBind(bk_forward,        keyboard, 'w');
     AddBind(bk_backward,       keyboard, 's');
@@ -684,6 +734,8 @@ void BK_ApplyDefaultBindings()
 
     // Controller
     AddBind(bk_look_center, controller, CONTROLLER_RIGHT_STICK);
+
+    bindClearEnabled = true;
 }
 
 void BK_LoadBindings(void* file)


### PR DESCRIPTION
- Prohibit binding of keyboard and gamepad keys hardcoded for menu shortcuts.
- Allow only "One key to one Function, one Function to many keys" binds. Adding new key binding will clear all bindings of that key from other functions.
- Added missing jump binding to Hexen controls menu. Part of #273 