### PR TITLE
Doom: optimize status bar drawing

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -632,7 +632,6 @@ void D_Display (void)
             AM_Drawer ();
         }
 
-        ST_Drawer ();
         break;
 
         case GS_INTERMISSION:
@@ -665,20 +664,7 @@ void D_Display (void)
             }
         }
 
-        if (aspect_ratio >= 2)
-        {
-            if (screenblocks > 10 && screenblocks < 17)
-            {
-                ST_Drawer();
-            }
-        }
-        else
-        {
-            if (screenblocks == 11 || screenblocks == 12 || screenblocks == 13)
-            {
-                ST_Drawer();
-            }
-        }
+        ST_Drawer();
     }
 
     // clean up border stuff

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -648,22 +648,27 @@ void D_Display (void)
     }
 
     // draw the view directly
-    if (gamestate == GS_LEVEL && (!automapactive || automap_overlay) && gametic)
+    if (gamestate == GS_LEVEL && gametic)
     {
-        R_RenderPlayerView (&players[displayplayer]);
-
-        // [JN] Background opacity in automap overlay mode.
-        if (automapactive && automap_overlay)
+        if (!automapactive || automap_overlay)
         {
-            const int screenheight = screenblocks > 10 ?
-                                     SCREENHEIGHT : SCREENHEIGHT - (st_height << hires);
+            R_RenderPlayerView (&players[displayplayer]);
 
-            for (y = 0 ; y < screenwidth * screenheight ; y++)
+            // [JN] Background opacity in automap overlay mode.
+            if (automapactive && automap_overlay)
             {
-                I_VideoBuffer[y] = colormaps[automap_overlay_bg * 256 + I_VideoBuffer[y]];
+                const int screenheight = screenblocks > 10 ?
+                                         SCREENHEIGHT : SCREENHEIGHT - (st_height << hires);
+
+                for (y = 0 ; y < screenwidth * screenheight ; y++)
+                {
+                    I_VideoBuffer[y] = colormaps[automap_overlay_bg * 256 + I_VideoBuffer[y]];
+                }
             }
         }
 
+        // [JN] Do red-/gold-shifts from damage/items and
+        // draw full screen status bar in appropriated sizes.
         ST_Drawer();
     }
 

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -1433,7 +1433,6 @@ static void ST_DrawSmallNumberG (int val, int x, int y)
 
 static void ST_DrawValues (boolean wide)
 {
-    printf ("."); // [JN] TODO - remove once everything will be checked
     int left_delta;
     int right_delta;
     
@@ -1447,6 +1446,8 @@ static void ST_DrawValues (boolean wide)
         left_delta = wide_delta;
         right_delta = wide_delta;
     }
+
+    printf ("."); // [JN] TODO - remove once everything will be checked
 
     // Transparent signs
     if (screenblocks == 11 || screenblocks == 12
@@ -1961,7 +1962,7 @@ void ST_Drawer (void)
     // Do red-/gold-shifts from damage/items
     ST_DoPaletteStuff();
 
-    if (screenblocks > 10 && screenblocks < 14
+    if (screenblocks > 10 && screenblocks < 17
     && (!automapactive || automap_overlay))
     {
         ST_DrawValuesFunc(screenblocks >= 14 ? true : false);

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -1962,11 +1962,11 @@ void ST_Drawer (void)
     // Do red-/gold-shifts from damage/items
     ST_DoPaletteStuff();
 
-    if (screenblocks > 10 && screenblocks < 17
-    && (!automapactive || automap_overlay))
-    {
-        ST_DrawValuesFunc(screenblocks >= 14 ? true : false);
-    }
+        if (screenblocks > 10 && screenblocks < (aspect_ratio >= 2 ? 17 : 14)
+        && (!automapactive || automap_overlay))
+        {
+            ST_DrawValuesFunc(screenblocks >= 14 ? true : false);
+        }
 }
 
 // -----------------------------------------------------------------------------

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -1103,6 +1103,7 @@ void ST_Ticker (void)
     if (screenblocks <= 10 || (automapactive && !automap_overlay))
     {
         ST_UpdateBackground();
+        ST_DrawValuesFunc(false);
     }
 
     // [JN] Use real random number generator
@@ -1432,6 +1433,7 @@ static void ST_DrawSmallNumberG (int val, int x, int y)
 
 static void ST_DrawValues (boolean wide)
 {
+    printf ("."); // [JN] TODO - remove once everything will be checked
     int left_delta;
     int right_delta;
     
@@ -1959,11 +1961,8 @@ void ST_Drawer (void)
     // Do red-/gold-shifts from damage/items
     ST_DoPaletteStuff();
 
-    if (screenblocks <= 10 || (automapactive && !automap_overlay))
-    {
-        ST_DrawValuesFunc(false);
-    }
-    else
+    if (screenblocks > 10 && screenblocks < 14
+    && (!automapactive || automap_overlay))
     {
         ST_DrawValuesFunc(screenblocks >= 14 ? true : false);
     }


### PR DESCRIPTION
After I've removed `ST_drawDiff` while refactoring, status bar background is redrawing constantly, every single tick. For example, if FPS value is capped to 200, background is redrawing 200 times per second. The idea is to redraw background not via `ST_Drawer`, but via `ST_Ticker` which is called only 35 times per second. 

Buffered drawing should do it's job just fine, so no blinking will appear.