### PR TITLE
Add check for Windows 11 in `DisableWinRound`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -235,7 +235,7 @@ foreach(MODULE ${COMPILE_MODULES})
     set_tests_properties("${PROGRAM_PREFIX}${MODULE}" PROPERTIES
         PASS_REGULAR_EXPRESSION "Насчитано [0-9]+ gametics в [0-9]+ realtics;Timed [0-9]+ gametics in [0-9]+ realtics"
         FAIL_REGULAR_EXPRESSION "SEGV"
-        TIMEOUT 60
+        TIMEOUT 150
     )
 endforeach()
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1397,7 +1397,7 @@ static void CenterWindow(int *x, int *y, int w, int h)
     *y = bounds.y + SDL_max((bounds.h - h) / 2, 0);
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 extern void DisableWinRound(SDL_Window* screen);
 #endif
 
@@ -1483,7 +1483,7 @@ static void SetVideoMode(void)
             SDL_GetError());
         }
 
-#ifdef WIN32
+#ifdef _WIN32
         DisableWinRound(screen);
 #endif
 

--- a/src/rd_io.h
+++ b/src/rd_io.h
@@ -1,23 +1,18 @@
 //
-//  Copyright(C) 2021 Roman Fomin
+// Copyright(C) 2021 Roman Fomin
 //
-//  This program is free software; you can redistribute it and/or
-//  modify it under the terms of the GNU General Public License
-//  as published by the Free Software Foundation; either version 2
-//  of the License, or (at your option) any later version.
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program; if not, write to the Free Software
-//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-//  02111-1307, USA.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
 //
 // DESCRIPTION:
-//      unicode paths for fopen() on Windows
+//  unicode paths for fopen() on Windows
 
 
 #pragma once

--- a/src/win_compat.c
+++ b/src/win_compat.c
@@ -123,10 +123,12 @@ int I_CheckWindows11(void)
     return 0;
 }
 
+typedef HRESULT (WINAPI *PDWMSETWINDOWATTRIBUTE)(HWND, DWORD, LPCVOID, DWORD);
+
 void DisableWinRound(SDL_Window* screen)
 {
     HMODULE hDllDwmApi;
-    HRESULT (*pDwmSetWindowAttribute) (HWND, DWORD, LPCVOID, DWORD);
+    PDWMSETWINDOWATTRIBUTE pDwmSetWindowAttribute;
     SDL_SysWMinfo wmInfo;
     HWND hwnd;
     int noround = 1; // DWMWCP_DONOTROUND
@@ -138,7 +140,7 @@ void DisableWinRound(SDL_Window* screen)
     hDllDwmApi = LoadLibrary("dwmapi.dll");
     if(hDllDwmApi != NULL)
     {
-        pDwmSetWindowAttribute = (HRESULT (*)(HWND, DWORD, LPCVOID, DWORD)) GetProcAddress(hDllDwmApi, "DwmSetWindowAttribute");
+        pDwmSetWindowAttribute = (PDWMSETWINDOWATTRIBUTE) GetProcAddress(hDllDwmApi, "DwmSetWindowAttribute");
     }
     if(pDwmSetWindowAttribute != NULL)
     {


### PR DESCRIPTION
I give up. I just can't understand why call of `DwmSetWindowAttribute` leads to `SIGSEGV 0x00000280 in ??` for 32 bit builds in `Release` or `RelWithDebInfo` build types.