### PR TITLE
Setup: Update WINDOW_HELP_URL urls

### DIFF
--- a/src/setup/compatibility.c
+++ b/src/setup/compatibility.c
@@ -22,7 +22,7 @@
 
 #include "compatibility.h"
 
-#define WINDOW_HELP_URL "https://jnechaevsky.github.io/projects/rusdoom/setup/index.html"
+#define WINDOW_HELP_URL "https://github.com/JNechaevsky/inter-doom/wiki"
 
 
 // Display

--- a/src/setup/display.c
+++ b/src/setup/display.c
@@ -31,7 +31,7 @@
 #include "display.h"
 #include "config.h"
 
-#define WINDOW_HELP_URL "https://jnechaevsky.github.io/projects/rusdoom/setup/index.html"
+#define WINDOW_HELP_URL "https://github.com/JNechaevsky/inter-doom/wiki"
 
 extern void RestartTextscreen(void);
 

--- a/src/setup/mainmenu.c
+++ b/src/setup/mainmenu.c
@@ -43,7 +43,7 @@
 #include "multiplayer.h"
 #include "sound.h"
 
-#define WINDOW_HELP_URL "https://jnechaevsky.github.io/projects/rusdoom/setup/index.html"
+#define WINDOW_HELP_URL "https://github.com/JNechaevsky/inter-doom/wiki"
 
 // -----------------------------------------------------------------------------
 // [Dasperal] d_name.h var definition

--- a/src/setup/mouse.c
+++ b/src/setup/mouse.c
@@ -22,7 +22,7 @@
 #include "mode.h"
 #include "mouse.h"
 
-#define WINDOW_HELP_URL "https://jnechaevsky.github.io/projects/rusdoom/setup/index.html"
+#define WINDOW_HELP_URL "https://github.com/JNechaevsky/inter-doom/wiki"
 
 static int usemouse = 1;
 

--- a/src/setup/multiplayer.c
+++ b/src/setup/multiplayer.c
@@ -36,7 +36,7 @@
 #include "net_io.h"
 #include "net_query.h"
 
-#define WINDOW_HELP_URL "https://jnechaevsky.github.io/projects/rusdoom/setup/index.html"
+#define WINDOW_HELP_URL "https://github.com/JNechaevsky/inter-doom/wiki"
 
 #define NUM_WADS 10
 #define NUM_EXTRA_PARAMS 10

--- a/src/setup/sound.c
+++ b/src/setup/sound.c
@@ -28,7 +28,7 @@
 #include "mode.h"
 #include "sound.h"
 
-#define WINDOW_HELP_URL "https://jnechaevsky.github.io/projects/rusdoom/setup/index.html"
+#define WINDOW_HELP_URL "https://github.com/JNechaevsky/inter-doom/wiki"
 
 typedef enum
 {


### PR DESCRIPTION
Update the old help URL to the new GitHub wiki (unless there's another one I'm not aware of).