### PR TITLE
Doom: run `canmodify` loops only once per level

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -3261,7 +3261,7 @@ void D_DoomMain (void)
         char* arg = myargv[p + 1];
         char* result;
 
-        // [JN] Allow to apply map fixes for new game.
+        // [JN] Allow to apply map fixes for new warp game.
         canapplyfixes = true;
 
         if(gamemode == commercial)

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -3260,6 +3260,10 @@ void D_DoomMain (void)
     {
         char* arg = myargv[p + 1];
         char* result;
+
+        // [JN] Allow to apply map fixes for new game.
+        canapplyfixes = true;
+
         if(gamemode == commercial)
         {
             if(M_StringStartsWith(arg, "MAP") || M_StringStartsWith(arg, "map"))

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1963,6 +1963,9 @@ void G_DoSelectiveGame (int choice)
     // Close "Level select" menu
     RD_Menu_DeactivateMenu(false);
 
+    // [JN] Allow to apply map fixes for new game.
+    canapplyfixes = true;
+
     G_InitNew (selective_skill,
                // Set appropriate episode
                gamemode == shareware  ? 1 : 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1963,7 +1963,7 @@ void G_DoSelectiveGame (int choice)
     // Close "Level select" menu
     RD_Menu_DeactivateMenu(false);
 
-    // [JN] Allow to apply map fixes for new game.
+    // [JN] Allow to apply map fixes for new selective game.
     canapplyfixes = true;
 
     G_InitNew (selective_skill,

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1761,6 +1761,9 @@ void G_DoLoadGame (void)
 
     savedleveltime = leveltime;
 
+    // [JN] Do not allow to apply map fixes for loaded savegame.
+    canapplyfixes = false;
+
     // load a base level 
     G_InitNew (gameskill, gameepisode, gamemap); 
  
@@ -1927,6 +1930,10 @@ void G_DoNewGame (void)
     nomonsters = false;
     */
     consoleplayer = 0;
+
+    // [JN] Allow to apply map fixes for new game.
+    canapplyfixes = true;
+
     G_InitNew (d_skill, d_episode, d_map); 
     gameaction = ga_nothing; 
     flag667 = false;

--- a/src/doom/p_local.h
+++ b/src/doom/p_local.h
@@ -554,6 +554,7 @@ void P_WriteSaveGameHeader (char *description);
 #define KEYBLINKTICS (7*KEYBLINKMASK)
 extern int st_keyorskull[3];
 
+extern boolean   canapplyfixes;
 extern byte     *rejectmatrix;  // for fast sight rejection
 extern int32_t  *blockmaplump;  // offsets in blockmap are from here // [crispy] BLOCKMAP limit
 extern int32_t  *blockmap;      // [crispy] BLOCKMAP limit

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -38,7 +38,7 @@
 
 
 boolean canmodify;
-boolean canapplyfixes;  // [JN] Apply map fixes only once.
+boolean canapplyfixes;  // [JN] Apply map fixes only once per map.
 
 // MAP related Lookup tables.
 // Store VERTEXES, LINEDEFS, SIDEDEFS, etc.
@@ -2269,8 +2269,8 @@ void P_SetupLevel (const int episode, const int map, const skill_t skill)
              && gamemode != pressbeta
              && gamemission != jaguar
              && gamevariant != freedoom && gamevariant != freedm))
-             && singleplayer
-             && canapplyfixes);
+             && canapplyfixes
+             && singleplayer);
 
     if (canapplyfixes)
     {

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -38,6 +38,7 @@
 
 
 boolean canmodify;
+boolean canapplyfixes;  // [JN] Apply map fixes only once.
 
 // MAP related Lookup tables.
 // Store VERTEXES, LINEDEFS, SIDEDEFS, etc.
@@ -2268,7 +2269,14 @@ void P_SetupLevel (const int episode, const int map, const skill_t skill)
              && gamemode != pressbeta
              && gamemission != jaguar
              && gamevariant != freedoom && gamevariant != freedm))
-             && singleplayer);
+             && singleplayer
+             && canapplyfixes);
+
+    if (canapplyfixes)
+    {
+        // [JN] TODO -- degug print!
+        printf (" ### CAN APPLY MAP FIXES! ### \n");
+    }
 
     leveltime = 0;
     oldleveltime = 0; // [crispy] Track if game is running

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -2274,7 +2274,7 @@ void P_SetupLevel (const int episode, const int map, const skill_t skill)
 
     if (canapplyfixes)
     {
-        // [JN] TODO -- degug print!
+        // [JN] TODO -- debug print!
         printf (" ### CAN APPLY MAP FIXES! ### \n");
     }
 

--- a/src/doom/p_setup.c
+++ b/src/doom/p_setup.c
@@ -2272,12 +2272,6 @@ void P_SetupLevel (const int episode, const int map, const skill_t skill)
              && canapplyfixes
              && singleplayer);
 
-    if (canapplyfixes)
-    {
-        // [JN] TODO -- debug print!
-        printf (" ### CAN APPLY MAP FIXES! ### \n");
-    }
-
     leveltime = 0;
     oldleveltime = 0; // [crispy] Track if game is running
 


### PR DESCRIPTION
The trick is to run `canmodify` loops ([here](https://github.com/JNechaevsky/inter-doom/blob/master/src/doom/p_setup.c#L386), [here](https://github.com/JNechaevsky/inter-doom/blob/master/src/doom/p_setup.c#L515), [here](https://github.com/JNechaevsky/inter-doom/blob/master/src/doom/p_setup.c#L759) and [here](https://github.com/JNechaevsky/inter-doom/blob/master/src/doom/p_setup.c#L1276)) only once per level, i.e. do not call it on savegame loading.
Acording to tests on loading savegame of TNT Map21 _(is it most complex vanilla map?)_, it reduces load time from ~12 ms. to ~2 ms. Fairly simple stopwatch is still here: [/src/doom/p_setup.c#L2367](https://github.com/JNechaevsky/inter-doom/blob/master/src/doom/p_setup.c#L2367)