### PR TITLE
Doom: replace K/I/S/SKL with frags counter in deathmatch

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -472,7 +472,7 @@ static byte *FadeMessage (int messageTics)
 
 void DrawMessage(void)
 {
-    player_t *player = &players[consoleplayer];
+    player_t *player = &players[displayplayer];
 
     // [JN] Activate message counter in non-level or paused states.
     // Make messages go away in menu, finale and help screens.

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -391,7 +391,7 @@ void D_ProcessEvents(void)
 
 static byte *ColorizeMessage (MessageType_t messageType)
 {
-    player_t *player = &players[consoleplayer];
+    player_t *player = &players[displayplayer];
 
     if (player->messageType == msg_pickup)
     {

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -2736,22 +2736,13 @@ void G_DoPlayDemo (void)
     
     // [crispy] demo progress bar
     {
-        int i, numplayersingame = 0;
         byte *demo_ptr = demo_p;
-
-        for (i = 0; i < MAXPLAYERS; i++)
-        {
-            if (playeringame[i])
-            {
-                numplayersingame++;
-            }
-        }
 
         deftotaldemotics = defdemotics = 0;
 
         while (*demo_ptr != DEMOMARKER && (demo_ptr - demobuffer) < lumplength)
         {
-            demo_ptr += numplayersingame * (longtics ? 5 : 4);
+            demo_ptr += (longtics ? 5 : 4);
             deftotaldemotics++;
         }
     }

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -834,19 +834,19 @@ static Menu_t AutomapMenu = {
 // -----------------------------------------------------------------------------
 
 static MenuItem_t StatsItems[] = {
-    {ITT_TITLE,   "Statistics",     "Cnfnbcnbrf",         NULL,                         0}, // Статистика
-    {ITT_LRFUNC,  "level stats:",   "cnfnbcnbrf ehjdyz:", M_RD_Change_AutomapStats,     0}, // Статистика уровня:
-    {ITT_LRFUNC,  "skill level:",   "ehjdtym ckj;yjcnb:", M_RD_Change_AutomapSkill,     0}, // Уровень сложности:
-    {ITT_LRFUNC,  "level time:",    "dhtvz ehjdyz:",      M_RD_Change_AutomapLevelTime, 0}, // Время уровня:
-    {ITT_LRFUNC,  "total time:",    "j,ott dhtvz:",       M_RD_Change_AutomapTotalTime, 0}, // Общее время:
-    {ITT_LRFUNC,  "player coords:", "rjjhlbyfns buhjrf:", M_RD_Change_AutomapCoords,    0}, // Координаты игрока:
-    {ITT_SWITCH,  "coloring:",      "jrhfibdfybt:",       M_RD_Change_HUDWidgetColors,  0}, // Окрашивание:
-    {ITT_EMPTY,   NULL,             NULL,                 NULL,                         0},
-    {ITT_EMPTY,   NULL,             NULL,                 NULL,                         0},
-    {ITT_EMPTY,   NULL,             NULL,                 NULL,                         0},
-    {ITT_EMPTY,   NULL,             NULL,                 NULL,                         0},
-    {ITT_EMPTY,   NULL,             NULL,                 NULL,                         0},
-    {ITT_SETMENU, NULL,             NULL,                 &AutomapMenu,                 0}
+    {ITT_TITLE,   "Statistics",         "Cnfnbcnbrf",               NULL,                         0}, // Статистика
+    {ITT_LRFUNC,  "level stats/frags:", "cnfnbcnbrf ehjdyz*ahfub:", M_RD_Change_AutomapStats,     0}, // Статистика уровня/фраги:
+    {ITT_LRFUNC,  "skill level:",       "ehjdtym ckj;yjcnb:",       M_RD_Change_AutomapSkill,     0}, // Уровень сложности:
+    {ITT_LRFUNC,  "level time:",        "dhtvz ehjdyz:",            M_RD_Change_AutomapLevelTime, 0}, // Время уровня:
+    {ITT_LRFUNC,  "total time:",        "j,ott dhtvz:",             M_RD_Change_AutomapTotalTime, 0}, // Общее время:
+    {ITT_LRFUNC,  "player coords:",     "rjjhlbyfns buhjrf:",       M_RD_Change_AutomapCoords,    0}, // Координаты игрока:
+    {ITT_SWITCH,  "coloring:",          "jrhfibdfybt:",             M_RD_Change_HUDWidgetColors,  0}, // Окрашивание:
+    {ITT_EMPTY,   NULL,                 NULL,                       NULL,                         0},
+    {ITT_EMPTY,   NULL,                 NULL,                       NULL,                         0},
+    {ITT_EMPTY,   NULL,                 NULL,                       NULL,                         0},
+    {ITT_EMPTY,   NULL,                 NULL,                       NULL,                         0},
+    {ITT_EMPTY,   NULL,                 NULL,                       NULL,                         0},
+    {ITT_SETMENU, NULL,                 NULL,                       &AutomapMenu,                 0}
 };
 
 static Menu_t StatsMenu = {
@@ -2729,10 +2729,10 @@ static void M_RD_Draw_StatsSettings(void)
 {
     if (english_language)
     {
-        // Level stats
+        // Level stats/frags
         RD_M_DrawTextSmallENG(automap_stats == 1 ? "in automap" :
                               automap_stats == 2 ? "always" : "off",
-                              124 + wide_delta, 35,
+                              170 + wide_delta, 35,
                               automap_stats ? CR_GREEN : CR_DARKRED);
 
         // Skill level
@@ -2771,10 +2771,10 @@ static void M_RD_Draw_StatsSettings(void)
     }
     else
     {
-        // Статистика уровня
+        // Статистика уровня/фраги
         RD_M_DrawTextSmallRUS(automap_stats == 1 ? "yf rfhnt" :
                               automap_stats == 2 ? "dctulf" :
-                              "dsrk", 175 + wide_delta, 35,
+                              "dsrk", 224 + wide_delta, 35,
                               automap_stats ? CR_GREEN : CR_DARKRED);
 
         // Уровень сложности

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -893,7 +893,8 @@ static void P_KillMobj (const mobj_t *source, mobj_t *target)
 
         P_DropWeapon (target->player);
 
-        if (target->player == &players[consoleplayer] && automapactive)
+        if (target->player == &players[consoleplayer] && automapactive
+        && !demoplayback) // [JN] Don't close automap while demo playing.
         {
             // don't die in auto map,
             // switch view prior to dying

--- a/src/doom/r_local.h
+++ b/src/doom/r_local.h
@@ -539,6 +539,8 @@ void R_DrawTLColumn (void);
 void R_DrawTLColumnLow (void);
 void R_DrawTranslatedColumn (void);
 void R_DrawTranslatedColumnLow (void);
+void R_DrawTranslatedTLColumn (void);
+void R_DrawTranslatedTLColumnLow (void);
 void R_DrawViewBorder (void);
 void R_FillBackScreen (void);
 void R_InitBackScreenGfx (void);
@@ -592,6 +594,7 @@ extern void (*fuzzcolfunc) (void);
 extern void (*spanfunc) (void);
 extern void (*tlcolfunc) (void);
 extern void (*transcolfunc) (void);
+extern void (*transtlcolfunc) (void);
 extern void (*ghostcolfunc) (void);
 extern void R_ClearStats (void);
 

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -92,6 +92,7 @@ void (*basecolfunc) (void);
 void (*fuzzcolfunc) (void);
 void (*transcolfunc) (void);
 void (*tlcolfunc) (void);
+void (*transtlcolfunc) (void);
 void (*ghostcolfunc) (void);
 void (*spanfunc) (void);
 
@@ -615,6 +616,7 @@ void R_ExecuteSetViewSize (void)
                                                             R_DrawFuzzColumnTranslucent;
         transcolfunc = R_DrawTranslatedColumn;
         tlcolfunc = R_DrawTLColumn;
+        transtlcolfunc = R_DrawTranslatedTLColumn;
         ghostcolfunc = R_DrawGhostColumn;
         spanfunc = R_DrawSpan;
     }
@@ -629,6 +631,7 @@ void R_ExecuteSetViewSize (void)
         transcolfunc = R_DrawTranslatedColumnLow;
         tlcolfunc = R_DrawTLColumnLow;
         ghostcolfunc = R_DrawGhostColumnLow;
+        transtlcolfunc = R_DrawTranslatedTLColumnLow;
         spanfunc = R_DrawSpanLow;
     }
 

--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -494,7 +494,7 @@ static void R_DrawVisSprite (const vissprite_t *vis, const int x1, const int x2)
     // [JN] Translucent fuzz effect.
     if (vis->mobjflags & MF_SHADOW && improved_fuzz == 4)
     {
-        colfunc = fuzzcolfunc;
+        colfunc = vis->mobjflags & MF_TRANSLATION ? transtlcolfunc : fuzzcolfunc;
     }
 
     // [JN] Ghost monsters.

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -1143,7 +1143,7 @@ static void ST_updateFaceWidget (void)
 // [JN] Updated to int type, allowing to show frags of any player.
 // -----------------------------------------------------------------------------
 
-static int ST_UpdateFragsCounter (int playernum, boolean big_values)
+static const int ST_UpdateFragsCounter (const int playernum, const boolean big_values)
 {
     st_fragscount = 0;
 

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -2267,7 +2267,7 @@ static void ST_LoadData (void)
 void ST_Start (void)
 {
     I_SetPalette (W_CacheLumpNum ((lu_palette), PU_CACHE));
-    plyr = &players[consoleplayer];
+    plyr = &players[displayplayer];
 
     faceindex = 1; // [crispy] fix status bar face hysteresis across level changes
     st_faceindex = 1;

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -840,7 +840,7 @@ static void ST_DrawBackground (void)
     // Face background representing player color.
     if (netgame)
     {
-        V_DrawPatch(143 + wide_delta, 0, faceback_1[consoleplayer], NULL);
+        V_DrawPatch(143 + wide_delta, 0, faceback_1[displayplayer], NULL);
     }
 
     V_RestoreBuffer();
@@ -1140,30 +1140,36 @@ static void ST_updateFaceWidget (void)
 
 // -----------------------------------------------------------------------------
 // ST_UpdateFragsCounter
+// [JN] Updated to int type, allowing to show frags of any player.
 // -----------------------------------------------------------------------------
 
-static void ST_UpdateFragsCounter (void)
+static int ST_UpdateFragsCounter (int playernum, boolean big_values)
 {
     st_fragscount = 0;
 
     for (int i = 0 ; i < MAXPLAYERS ; i++)
     {
-        if (i != consoleplayer)
+        if (i != playernum)
         {
-            st_fragscount += plyr->frags[i];
+            st_fragscount += players[playernum].frags[i];
         }
         else
         {
-            st_fragscount -= plyr->frags[i];
+            st_fragscount -= players[playernum].frags[i];
         }
     }
     
     // [JN] Prevent overflow, ST_DrawBigNumber can only draw three 
     // digit number, and status bar fits well only two digits number
-    if (st_fragscount > 99)
-        st_fragscount = 99;
-    if (st_fragscount < -99)
-        st_fragscount = -99;
+    if (!big_values)
+    {
+        if (st_fragscount > 99)
+            st_fragscount = 99;
+        if (st_fragscount < -99)
+            st_fragscount = -99;
+    }
+
+    return st_fragscount;
 }
 
 // -----------------------------------------------------------------------------
@@ -1276,11 +1282,6 @@ void ST_Ticker (void)
         {
             plyr->tryopen[i]--;
         }
-    }
-
-    if (deathmatch)
-    {
-        ST_UpdateFragsCounter();
     }
     
     st_oldhealth = plyr->health;
@@ -1611,6 +1612,7 @@ static void ST_DrawElements (const boolean wide)
     // Frags or Arms
     if (deathmatch)
     {
+        st_fragscount = ST_UpdateFragsCounter(displayplayer, false);
         ST_DrawBigNumber(st_fragscount, 100 + left_delta, 171, ST_WidgetColor(hudcolor_frags));
     }
     else
@@ -1640,7 +1642,7 @@ static void ST_DrawElements (const boolean wide)
     // Player face background
     if ((screenblocks == 11 || screenblocks == 14) && (!automapactive || automap_overlay))
     {
-        V_DrawPatch(143 + wide_delta, 168, faceback_2[netgame ? consoleplayer : 1], NULL);        
+        V_DrawPatch(143 + wide_delta, 168, faceback_2[netgame ? displayplayer : 1], NULL);        
     }
 
     // Player face
@@ -1885,64 +1887,103 @@ void ST_WidgetsDrawer (void)
     const int totaltime = (totalleveltimes / TICRATE) + (leveltime / TICRATE);
     const int wide_4_3 = aspect_ratio >= 2 && screenblocks == 9 ? wide_delta : 0;
     const int net_y = netgame ? 8 : 0;  // [JN] Shift one line down for chat string.
-    plyr = &players[consoleplayer];
+    plyr = &players[displayplayer];
 
-    if (((automapactive && automap_stats == 1) || automap_stats == 2))
+    // Level stats / Frags:
+    if (deathmatch)
     {
-        // Kills:
-        sprintf(str, plyr->extrakillcount ? "%d+%d/%d" : "%d/%d",
-                plyr->killcount,
-                plyr->extrakillcount ? plyr->extrakillcount : totalkills,
-                totalkills);
-
-        english_language ? RD_M_DrawTextA("K:", wide_4_3, 9+net_y) :
-                           RD_M_DrawTextSmallRUS("D:", wide_4_3, 9+net_y, CR_NONE);
-        
-        dp_translation = hud_stats_color == 0 ? NULL :
-                         totalkills == 0 ? cr[CR_GREEN] :
-                         plyr->killcount == 0 ? cr[CR_RED] :
-                         plyr->killcount < totalkills ? cr[CR_YELLOW] : cr[CR_GREEN];
-        RD_M_DrawTextA(str, wide_4_3 + 16, 9+net_y);
-        dp_translation = NULL;
-
-        // Items:
-        sprintf(str, "%d/%d", plyr->itemcount, totalitems);
-
-        english_language ? RD_M_DrawTextA("I:", wide_4_3, 17+net_y) :
-                           RD_M_DrawTextSmallRUS("G:", wide_4_3, 17+net_y, CR_NONE);
-
-        dp_translation = hud_stats_color == 0 ? NULL :
-                         totalitems == 0 ? cr[CR_GREEN] :
-                         plyr->itemcount == 0 ? cr[CR_RED] :
-                         plyr->itemcount < totalitems ? cr[CR_YELLOW] : cr[CR_GREEN];
-        RD_M_DrawTextA(str, wide_4_3 + 16, 17+net_y);
-        dp_translation = NULL;
-
-        // Secret:
-        sprintf(str, "%d/%d", plyr->secretcount, totalsecret);
-
-        english_language ? RD_M_DrawTextA("S:", wide_4_3, 25+net_y) :
-                           RD_M_DrawTextSmallRUS("N:", wide_4_3, 25+net_y, CR_NONE);
-
-        dp_translation = hud_stats_color == 0 ? NULL :
-                         totalsecret == 0 ? cr[CR_GREEN] :
-                         plyr->secretcount == 0 ? cr[CR_RED] :
-                         plyr->secretcount < totalsecret ? cr[CR_YELLOW] : cr[CR_GREEN];
-        RD_M_DrawTextA(str, wide_4_3 + 16, 25+net_y);
-        dp_translation = NULL;
+        if (playeringame[0])
+        {
+            dp_translation = hud_stats_color == 0 ? NULL : cr[CR_GREEN];
+            RD_M_DrawTextA("G:", wide_4_3, 17);
+            sprintf(str, "%d", ST_UpdateFragsCounter(0, true));
+            RD_M_DrawTextA(str, wide_4_3 + 16, 17);
+            dp_translation = NULL;
+        }
+        if (playeringame[1])
+        {
+            dp_translation = hud_stats_color == 0 ? NULL : cr[CR_GRAY];
+            RD_M_DrawTextA("I:", wide_4_3, 25);
+            sprintf(str, "%d", ST_UpdateFragsCounter(1, true));
+            RD_M_DrawTextA(str, wide_4_3 + 16, 25);
+            dp_translation = NULL;
+        }
+        if (playeringame[2])
+        {
+            dp_translation = hud_stats_color == 0 ? NULL : cr[CR_BROWN];
+            RD_M_DrawTextA("B:", wide_4_3, 33);
+            sprintf(str, "%d", ST_UpdateFragsCounter(2, true));
+            RD_M_DrawTextA(str, wide_4_3 + 16, 33);
+            dp_translation = NULL;
+        }
+        if (playeringame[3])
+        {
+            dp_translation = hud_stats_color == 0 ? NULL : cr[CR_RED];
+            RD_M_DrawTextA("R:", wide_4_3, 41);
+            sprintf(str, "%d", ST_UpdateFragsCounter(3, true));
+            RD_M_DrawTextA(str, wide_4_3 + 16, 41);
+            dp_translation = NULL;
+        }
     }
-
-    // Skill Level:
-    if (((automapactive && automap_skill == 1) || automap_skill == 2))
+    else
     {
-        sprintf(str, "%d", gameskill+1);
-
-        english_language ? RD_M_DrawTextA("SKL:", wide_4_3, 33+net_y) :
-                           RD_M_DrawTextSmallRUS("CK;:", wide_4_3, 33+net_y, CR_NONE);
-
-        dp_translation = hud_stats_color == 0 ? NULL : cr[CR_WHITE];
-        RD_M_DrawTextA(str, wide_4_3 + (english_language ? 31 : 36), 33+net_y);
-        dp_translation = NULL;
+        if (((automapactive && automap_stats == 1) || automap_stats == 2))
+        {
+            // Kills:
+            sprintf(str, plyr->extrakillcount ? "%d+%d/%d" : "%d/%d",
+                    plyr->killcount,
+                    plyr->extrakillcount ? plyr->extrakillcount : totalkills,
+                    totalkills);
+        
+            english_language ? RD_M_DrawTextA("K:", wide_4_3, 9+net_y) :
+                               RD_M_DrawTextSmallRUS("D:", wide_4_3, 9+net_y, CR_NONE);
+            
+            dp_translation = hud_stats_color == 0 ? NULL :
+                             totalkills == 0 ? cr[CR_GREEN] :
+                             plyr->killcount == 0 ? cr[CR_RED] :
+                             plyr->killcount < totalkills ? cr[CR_YELLOW] : cr[CR_GREEN];
+            RD_M_DrawTextA(str, wide_4_3 + 16, 9+net_y);
+            dp_translation = NULL;
+        
+            // Items:
+            sprintf(str, "%d/%d", plyr->itemcount, totalitems);
+        
+            english_language ? RD_M_DrawTextA("I:", wide_4_3, 17+net_y) :
+                               RD_M_DrawTextSmallRUS("G:", wide_4_3, 17+net_y, CR_NONE);
+        
+            dp_translation = hud_stats_color == 0 ? NULL :
+                             totalitems == 0 ? cr[CR_GREEN] :
+                             plyr->itemcount == 0 ? cr[CR_RED] :
+                             plyr->itemcount < totalitems ? cr[CR_YELLOW] : cr[CR_GREEN];
+            RD_M_DrawTextA(str, wide_4_3 + 16, 17+net_y);
+            dp_translation = NULL;
+        
+            // Secret:
+            sprintf(str, "%d/%d", plyr->secretcount, totalsecret);
+        
+            english_language ? RD_M_DrawTextA("S:", wide_4_3, 25+net_y) :
+                               RD_M_DrawTextSmallRUS("N:", wide_4_3, 25+net_y, CR_NONE);
+        
+            dp_translation = hud_stats_color == 0 ? NULL :
+                             totalsecret == 0 ? cr[CR_GREEN] :
+                             plyr->secretcount == 0 ? cr[CR_RED] :
+                             plyr->secretcount < totalsecret ? cr[CR_YELLOW] : cr[CR_GREEN];
+            RD_M_DrawTextA(str, wide_4_3 + 16, 25+net_y);
+            dp_translation = NULL;
+        }
+        
+        // Skill Level:
+        if (((automapactive && automap_skill == 1) || automap_skill == 2))
+        {
+            sprintf(str, "%d", gameskill+1);
+        
+            english_language ? RD_M_DrawTextA("SKL:", wide_4_3, 33+net_y) :
+                               RD_M_DrawTextSmallRUS("CK;:", wide_4_3, 33+net_y, CR_NONE);
+        
+            dp_translation = hud_stats_color == 0 ? NULL : cr[CR_WHITE];
+            RD_M_DrawTextA(str, wide_4_3 + (english_language ? 31 : 36), 33+net_y);
+            dp_translation = NULL;
+        }
     }
 
     // Level Time:


### PR DESCRIPTION
In this PR:

* Replaced K/I/S/SKL with frags counter in deathmatch.
* Replaced `consoleplayer` with `displayplayer` status bar entities, so spy mode (F12) will show appropriate status bar values of chosen player.
* Updated `ST_UpdateFragsCounter` to show frags of any player _(this counter is a mad house, TBH)_.

![image](https://user-images.githubusercontent.com/21193394/183311727-de43cd0d-ec5f-4efe-9b31-1273effb68c4.png)
