### PR TITLE
Game mechanics: strict Vanilla mode

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -212,6 +212,9 @@ int linear_sky = 1;
 int randomly_flipcorpses = 1;
 int flip_weapons = 0;
 
+// Gameplay: Game Mechanics
+int strict_mode = 0;
+
 // Gameplay: Status Bar
 int extra_player_faces = 1;
 int negative_health = 0;
@@ -943,6 +946,9 @@ void D_BindVariables(void)
     M_BindIntVariable("linear_sky",             &linear_sky);
     M_BindIntVariable("randomly_flipcorpses",   &randomly_flipcorpses);
     M_BindIntVariable("flip_weapons",           &flip_weapons);
+
+    // Gameplay: Game Mechanics
+    M_BindIntVariable("strict_mode",            &strict_mode);
 
     // Gameplay: Status bar
     M_BindIntVariable("extra_player_faces",     &extra_player_faces);

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -200,6 +200,9 @@ int selective_key_5 = 0;    // red skull key
 int selective_fast = 0;
 int selective_respawn = 0;
 
+// Gameplay: Game Mechanics
+int strict_mode = 0;
+
 // Gameplay: Graphical
 int brightmaps = 1;
 int fake_contrast = 0;
@@ -211,9 +214,6 @@ int invul_sky = 1;
 int linear_sky = 1;
 int randomly_flipcorpses = 1;
 int flip_weapons = 0;
-
-// Gameplay: Game Mechanics
-int strict_mode = 0;
 
 // Gameplay: Status Bar
 int extra_player_faces = 1;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -935,6 +935,9 @@ void D_BindVariables(void)
     M_BindIntVariable("mlook",                  &mlook);
     M_BindIntVariable("mouse_sensitivity",      &mouseSensitivity);
 
+    // Gameplay: Game Mechanics
+    M_BindIntVariable("strict_mode",            &strict_mode);
+
     // Gameplay: Graphical
     M_BindIntVariable("brightmaps",             &brightmaps);
     M_BindIntVariable("fake_contrast",          &fake_contrast);
@@ -946,9 +949,6 @@ void D_BindVariables(void)
     M_BindIntVariable("linear_sky",             &linear_sky);
     M_BindIntVariable("randomly_flipcorpses",   &randomly_flipcorpses);
     M_BindIntVariable("flip_weapons",           &flip_weapons);
-
-    // Gameplay: Game Mechanics
-    M_BindIntVariable("strict_mode",            &strict_mode);
 
     // Gameplay: Status bar
     M_BindIntVariable("extra_player_faces",     &extra_player_faces);

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -241,7 +241,7 @@ static boolean WeaponSelectable(weapontype_t weapon)
     && players[consoleplayer].weaponowned[wp_chainsaw]
     && !players[consoleplayer].powers[pw_strength])
     {
-        return (singleplayer);  // [crispy] yes, we can
+        return (singleplayer && !strict_mode && !vanillaparm);  // [crispy] yes, we can
     }
 
     return true;
@@ -697,7 +697,7 @@ void G_DoLoadLevel (void)
     } 
 
     // [JN] Pistol start
-    if (singleplayer && !vanillaparm && pistol_start)
+    if (singleplayer && pistol_start && !vanillaparm)
     {
         G_PlayerReborn(0);
     }

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1369,20 +1369,20 @@ static Menu_t Gameplay3Menu = {
 };
 
 static MenuItem_t Gameplay4Items[] = {
-    {ITT_TITLE,   "Physical",                            "Abpbrf",                          NULL,                       0}, // Физика
-    {ITT_SWITCH,  "Collision physics:",                  "abpbrf cnjkryjdtybq:",            M_RD_Change_ImprovedCollision, 0}, // Физика столкновений
-    {ITT_SWITCH,  "Walk over and under monsters:",       "Gthtvtotybt gjl*yfl vjycnhfvb:",  M_RD_Change_WalkOverUnder,  0}, // Перемещение над/под монстрами
-    {ITT_SWITCH,  "Corpses sliding from the ledges:",    "Nhegs cgjkpf.n c djpdsitybq:",    M_RD_Change_Torque,         0}, // Трупы сползают с возвышений
-    {ITT_SWITCH,  "Weapon bobbing while firing:",        "Ekexityyjt gjrfxbdfybt jhe;bz:",  M_RD_Change_Bobbing,        0}, // Улучшенное покачивание оружия
-    {ITT_SWITCH,  "Lethal pellet of a point-blank SSG:", "ldecndjkrf hfphsdftn dhfujd:",    M_RD_Change_SSGBlast,       0}, // Двустволка разрывает врагов
-    {ITT_LRFUNC,  "Floating powerups amplitude:",        "gjrfxbdfybt cath-fhntafrnjd:",    M_RD_Change_FloatPowerups,  0}, // Покачивание сфер-артефактов
-    {ITT_SWITCH,  "Items are tossed when dropped:",      "Gjl,hfcsdfnm dsgfdibt ghtlvtns:", M_RD_Change_TossDrop,       0}, // Подбрасывать выпавшие предметы
-    {ITT_TITLE,   "Tactical",                            "Nfrnbrf",                         NULL,                        0}, // Тактика
-    {ITT_SWITCH,  "Notify of revealed secrets:",         "Cjj,ofnm j yfqltyyjv nfqybrt:",   M_RD_Change_SecretNotify,    0}, // Сообщать о найденном тайнике
-    {ITT_SWITCH,  "Infragreen light amp. visor:",        "Byahfptktysq dbpjh jcdtotybz:",   M_RD_Change_InfraGreenVisor, 0}, // Инфразеленый визор освещения
-    {ITT_LRFUNC,  "Horizontal autoaiming:",              "ujh> fdnjghbwtkbdfybt:",          M_RD_Change_HorizontalAiming,0}, // Гор. Автоприцеливание
-    {ITT_SETMENU, NULL, /* Next page >   */              NULL,                              &Gameplay5Menu,             0}, // Далее >
-    {ITT_SETMENU, NULL, /* < Prev page > */              NULL,                              &Gameplay3Menu,             0}  // < Назад
+    {ITT_TITLE,   "Physical",                      "Abpbrf",                         NULL,                          0}, // Физика
+    {ITT_SWITCH,  NULL,                            NULL,                             M_RD_Change_ImprovedCollision, 0}, // Физика столкновений
+    {ITT_SWITCH,  NULL,                            NULL,                             M_RD_Change_WalkOverUnder,     0}, // Перемещение над/под монстрами
+    {ITT_SWITCH,  NULL,                            NULL,                             M_RD_Change_Torque,            0}, // Трупы сползают с возвышений
+    {ITT_SWITCH,  "Weapon bobbing while firing:",  "Ekexityyjt gjrfxbdfybt jhe;bz:", M_RD_Change_Bobbing,           0}, // Улучшенное покачивание оружия
+    {ITT_SWITCH,  NULL,                            NULL,                             M_RD_Change_SSGBlast,          0}, // Двустволка разрывает врагов
+    {ITT_LRFUNC,  "Floating powerups amplitude:",  "gjrfxbdfybt cath-fhntafrnjd:",   M_RD_Change_FloatPowerups,     0}, // Покачивание сфер-артефактов
+    {ITT_SWITCH,  NULL,                            NULL,                             M_RD_Change_TossDrop,          0}, // Подбрасывать выпавшие предметы
+    {ITT_TITLE,   "Tactical",                      "Nfrnbrf",                        NULL,                          0}, // Тактика
+    {ITT_SWITCH,  "Notify of revealed secrets:",   "Cjj,ofnm j yfqltyyjv nfqybrt:",  M_RD_Change_SecretNotify,      0}, // Сообщать о найденном тайнике
+    {ITT_SWITCH,  "Infragreen light amp. visor:",  "Byahfptktysq dbpjh jcdtotybz:",  M_RD_Change_InfraGreenVisor,   0}, // Инфразеленый визор освещения
+    {ITT_LRFUNC,  NULL,                            NULL,                             M_RD_Change_HorizontalAiming,  0}, // Гор. Автоприцеливание
+    {ITT_SETMENU, NULL, /* Next page >   */        NULL,                             &Gameplay5Menu,                0}, // Далее >
+    {ITT_SETMENU, NULL, /* < Prev page > */        NULL,                             &Gameplay3Menu,                0}  // < Назад
 };
 
 static Menu_t Gameplay4Menu = {
@@ -1401,7 +1401,7 @@ static MenuItem_t Gameplay5Items[] = {
     {ITT_SWITCH,  "Fix errors of vanilla maps:",         "ecnhfyznm jib,rb jhbu> ehjdytq:", M_RD_Change_FixMapErrors,    0}, // Устранять ошибки ориг. уровней
     {ITT_SWITCH,  "Flip game levels:",                   "pthrfkmyjt jnhf;tybt ehjdytq:",   M_RD_Change_FlipLevels,      0}, // Зеркальное отражение уровней
     {ITT_SWITCH,  "Pain Elemental without Souls limit:", "'ktvtynfkm ,tp juhfybxtybz lei:", M_RD_Change_LostSoulsQty,    0}, // Элементаль без ограничения душ
-    {ITT_SWITCH,  "More aggressive lost souls:",         "gjdsityyfz fuhtccbdyjcnm lei:",   M_RD_Change_LostSoulsAgr,    0}, // Повышенная агрессивность душ
+    {ITT_SWITCH,  NULL,                                  NULL,                              M_RD_Change_LostSoulsAgr,    0}, // Повышенная агрессивность душ
     {ITT_SWITCH,  "Imitate player's breathing:",         "bvbnfwbz ls[fybz buhjrf:",        M_RD_Change_Breathing,       0}, // Имитация дыхания игрока
     {ITT_SWITCH,  "Pistol start game mode:",             NULL, /*[JN] Joint EN/RU string*/  M_RD_Change_PistolStart,     0}, // Режим игры "Pistol start"
     {ITT_TITLE,   "Demos",                               "Ltvjpfgbcb",                      NULL,                        0}, // Демозаписи
@@ -4482,24 +4482,62 @@ static void M_RD_Draw_Gameplay_4(void)
     if (english_language)
     {
         // Collision physics
-        RD_M_DrawTextSmallENG(improved_collision ? "IMPROVED" : "ORIGINAL", 160 + wide_delta, 35,
-                              improved_collision ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallENG("Collision physics:", 35 + wide_delta, 35,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallENG("N/A", 160 + wide_delta, 35, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallENG(improved_collision ? "IMPROVED" : "ORIGINAL", 160 + wide_delta, 35,
+                                  improved_collision ? CR_GREEN : CR_DARKRED);
+        }
 
         // Walk over and under monsters
-        RD_M_DrawTextSmallENG(over_under ? RD_ON : RD_OFF, 250 + wide_delta, 45,
-                              over_under ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallENG("Walk over and under monsters:", 35 + wide_delta, 45,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallENG("N/A", 250 + wide_delta, 45, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallENG(over_under ? RD_ON : RD_OFF, 250 + wide_delta, 45,
+                                  over_under ? CR_GREEN : CR_DARKRED);
+        }
 
         // Corpses sliding from the ledges
-        RD_M_DrawTextSmallENG(torque ? RD_ON : RD_OFF, 264 + wide_delta, 55,
-                              torque ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallENG("Corpses sliding from the ledges:", 35 + wide_delta, 55,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallENG("N/A", 264 + wide_delta, 55, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallENG(torque ? RD_ON : RD_OFF, 264 + wide_delta, 55,
+                                  torque ? CR_GREEN : CR_DARKRED);
+        }
 
         // Weapon bobbing while firing
         RD_M_DrawTextSmallENG(weapon_bobbing ? RD_ON : RD_OFF, 233 + wide_delta, 65,
                               weapon_bobbing ? CR_GREEN : CR_DARKRED);
 
         // Lethal pellet of a point-blank SSG
-        RD_M_DrawTextSmallENG(ssg_blast_enemies ? RD_ON : RD_OFF, 287 + wide_delta, 75,
-                              ssg_blast_enemies ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallENG("Lethal pellet of a point-blank SSG:", 35 + wide_delta, 75,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallENG("N/A", 287 + wide_delta, 75, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallENG(ssg_blast_enemies ? RD_ON : RD_OFF, 287 + wide_delta, 75,
+                                  ssg_blast_enemies ? CR_GREEN : CR_DARKRED);
+        }
 
         // Floating powerups
         RD_M_DrawTextSmallENG(floating_powerups == 1 ? "LOW" : 
@@ -4508,8 +4546,20 @@ static void M_RD_Draw_Gameplay_4(void)
                               244 + wide_delta, 85, floating_powerups ? CR_GREEN : CR_DARKRED);
 
         // Items are tossed when dropped
-        RD_M_DrawTextSmallENG(toss_drop ? RD_ON : RD_OFF, 254 + wide_delta, 95,
-                              toss_drop ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallENG("Items are tossed when dropped:", 35 + wide_delta, 95,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallENG("N/A", 254 + wide_delta, 95, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallENG(toss_drop ? RD_ON : RD_OFF, 254 + wide_delta, 95,
+                                  toss_drop ? CR_GREEN : CR_DARKRED);
+        }
+
+
 
         // Notify of revealed secrets
         RD_M_DrawTextSmallENG(secret_notification ? RD_ON : RD_OFF,232 + wide_delta, 115,
@@ -4520,14 +4570,24 @@ static void M_RD_Draw_Gameplay_4(void)
                               infragreen_visor ? CR_GREEN : CR_DARKRED);
 
         // Horizontal autoaiming
-        RD_M_DrawTextSmallENG(horizontal_autoaim == 0 ? "hitscans only" : 
-                              horizontal_autoaim == 1 ? "projectiles only" :
-                              horizontal_autoaim == 2 ? "off" : 
-                                                        "on", 195 + wide_delta, 135,
-                              horizontal_autoaim == 0 ? CR_DARKGREEN :
-                              horizontal_autoaim == 1 ? CR_DARKGREEN :
-                              horizontal_autoaim == 2 ? CR_DARKRED : 
-                                                        CR_GREEN);
+        RD_M_DrawTextSmallENG("Horizontal autoaiming:", 35 + wide_delta, 135,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallENG("N/A", 195 + wide_delta, 135, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallENG(horizontal_autoaim == 0 ? "hitscans only" : 
+                                  horizontal_autoaim == 1 ? "projectiles only" :
+                                  horizontal_autoaim == 2 ? "off" : 
+                                                            "on", 195 + wide_delta, 135,
+                                  horizontal_autoaim == 0 ? CR_DARKGREEN :
+                                  horizontal_autoaim == 1 ? CR_DARKGREEN :
+                                  horizontal_autoaim == 2 ? CR_DARKRED : 
+                                                            CR_GREEN);
+        }
 
         //
         // Footer
@@ -4538,24 +4598,64 @@ static void M_RD_Draw_Gameplay_4(void)
     else
     {
         // Физика столкновений
-        RD_M_DrawTextSmallRUS(improved_collision ? "EKEXITYYFZ" : "JHBUBYFKMYFZ", 193 + wide_delta, 35,
-                              improved_collision ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallRUS("abpbrf cnjkryjdtybq:", 35 + wide_delta, 35,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+                              
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallRUS("Y*L", 193 + wide_delta, 35, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallRUS(improved_collision ? "EKEXITYYFZ" : "JHBUBYFKMYFZ", 193 + wide_delta, 35,
+                                  improved_collision ? CR_GREEN : CR_DARKRED);
+        }
 
         // Перемещение под/над монстрами
-        RD_M_DrawTextSmallRUS(over_under ? RD_ON_RUS : RD_OFF_RUS, 274 + wide_delta, 45,
-                              over_under ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallRUS("Gthtvtotybt gjl*yfl vjycnhfvb:", 35 + wide_delta, 45,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallRUS("Y*L", 274 + wide_delta, 45, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallRUS(over_under ? RD_ON_RUS : RD_OFF_RUS, 274 + wide_delta, 45,
+                                  over_under ? CR_GREEN : CR_DARKRED);
+        }
 
         // Трупы сползают с возвышений
-        RD_M_DrawTextSmallRUS(torque ? RD_ON_RUS : RD_OFF_RUS, 256 + wide_delta, 55,
-                              torque ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallRUS("Nhegs cgjkpf.n c djpdsitybq:", 35 + wide_delta, 55,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallRUS("Y*L", 256 + wide_delta, 55, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallRUS(torque ? RD_ON_RUS : RD_OFF_RUS, 256 + wide_delta, 55,
+                                  torque ? CR_GREEN : CR_DARKRED);
+        }
 
         // Улучшенное покачивание оружия
         RD_M_DrawTextSmallRUS(weapon_bobbing ? RD_ON_RUS : RD_OFF_RUS, 271 + wide_delta, 65,
                               weapon_bobbing ? CR_GREEN : CR_DARKRED);
 
         // Двустволка разрывает врагов
-        RD_M_DrawTextSmallRUS(ssg_blast_enemies ? RD_ON_RUS : RD_OFF_RUS, 254 + wide_delta, 75,
-                              ssg_blast_enemies ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallRUS("ldecndjkrf hfphsdftn dhfujd:", 35 + wide_delta, 75,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallRUS("Y*L", 254 + wide_delta, 75, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallRUS(ssg_blast_enemies ? RD_ON_RUS : RD_OFF_RUS, 254 + wide_delta, 75,
+                                  ssg_blast_enemies ? CR_GREEN : CR_DARKRED);
+        }
 
         // Амплитуда левитации артефактов
         RD_M_DrawTextSmallRUS(floating_powerups == 1 ? "CKF,JT"  :          // Слабое
@@ -4564,8 +4664,18 @@ static void M_RD_Draw_Gameplay_4(void)
                               256 + wide_delta, 85, floating_powerups ? CR_GREEN : CR_DARKRED);
 
         // Подбрасывать выпавшие предметы
-        RD_M_DrawTextSmallRUS(toss_drop ? RD_ON_RUS : RD_OFF_RUS, 285 + wide_delta, 95,
-                              toss_drop ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallRUS("Gjl,hfcsdfnm dsgfdibt ghtlvtns:", 35 + wide_delta, 95,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallRUS("Y*L", 285 + wide_delta, 95, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallRUS(toss_drop ? RD_ON_RUS : RD_OFF_RUS, 285 + wide_delta, 95,
+                                  toss_drop ? CR_GREEN : CR_DARKRED);
+        }
 
         // Сообщать о найденном тайнике
         RD_M_DrawTextSmallRUS(secret_notification ? RD_ON_RUS : RD_OFF_RUS, 260 + wide_delta, 115,
@@ -4576,14 +4686,24 @@ static void M_RD_Draw_Gameplay_4(void)
                               infragreen_visor ? CR_GREEN : CR_DARKRED);
 
         // Гор. автоприцеливание
-        RD_M_DrawTextSmallRUS(horizontal_autoaim == 0 ? "[bncrfys" :  // хитсканы
-                              horizontal_autoaim == 1 ? "cyfhzls" :   // снаряды
-                              horizontal_autoaim == 2 ? "dsrk" : 
-                                                        "drk", 204 + wide_delta, 135,
-                              horizontal_autoaim == 0 ? CR_DARKGREEN :
-                              horizontal_autoaim == 1 ? CR_DARKGREEN :
-                              horizontal_autoaim == 2 ? CR_DARKRED : 
-                                                        CR_GREEN);
+        RD_M_DrawTextSmallRUS("ujh> fdnjghbwtkbdfybt:", 35 + wide_delta, 135,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallRUS("Y*L", 204 + wide_delta, 135, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallRUS(horizontal_autoaim == 0 ? "[bncrfys" :  // хитсканы
+                                  horizontal_autoaim == 1 ? "cyfhzls" :   // снаряды
+                                  horizontal_autoaim == 2 ? "dsrk" : 
+                                                            "drk", 204 + wide_delta, 135,
+                                  horizontal_autoaim == 0 ? CR_DARKGREEN :
+                                  horizontal_autoaim == 1 ? CR_DARKGREEN :
+                                  horizontal_autoaim == 2 ? CR_DARKRED : 
+                                                            CR_GREEN);
+        }
 
 
 
@@ -4618,8 +4738,18 @@ static void M_RD_Draw_Gameplay_5(void)
                               unlimited_lost_souls ? CR_GREEN : CR_DARKRED);
 
         // More agressive lost souls
-        RD_M_DrawTextSmallENG(agressive_lost_souls ? RD_ON : RD_OFF, 230 + wide_delta, 65,
-                              agressive_lost_souls ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallENG("More aggressive lost souls:", 35 + wide_delta, 65,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallENG("N/A", 230 + wide_delta, 65, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallENG(agressive_lost_souls ? RD_ON : RD_OFF, 230 + wide_delta, 65,
+                                  agressive_lost_souls ? CR_GREEN : CR_DARKRED);
+        }
 
         // Imitate player's breathing
         RD_M_DrawTextSmallENG(breathing ? RD_ON : RD_OFF, 227 + wide_delta, 75,
@@ -4669,8 +4799,18 @@ static void M_RD_Draw_Gameplay_5(void)
                               unlimited_lost_souls ? CR_GREEN : CR_DARKRED);
 
         // Повышенная агрессивность Душ
-        RD_M_DrawTextSmallRUS(agressive_lost_souls ? RD_ON_RUS : RD_OFF_RUS, 266 + wide_delta, 65,
-                              agressive_lost_souls ? CR_GREEN : CR_DARKRED);
+        RD_M_DrawTextSmallRUS("gjdsityyfz fuhtccbdyjcnm lei:", 35 + wide_delta, 65,
+                              strict_mode || gamemission == jaguar ? CR_DARKRED : CR_NONE);
+
+        if (strict_mode)
+        {
+            RD_M_DrawTextSmallRUS("Y*L", 266 + wide_delta, 65, CR_DARKRED);
+        }
+        else
+        {
+            RD_M_DrawTextSmallRUS(agressive_lost_souls ? RD_ON_RUS : RD_OFF_RUS, 266 + wide_delta, 65,
+                                  agressive_lost_souls ? CR_GREEN : CR_DARKRED);
+        }
 
         // Имитация дыхания игрока
         RD_M_DrawTextSmallRUS(breathing ? RD_ON_RUS : RD_OFF_RUS, 225 + wide_delta, 75,
@@ -4966,16 +5106,31 @@ static void M_RD_Change_CrosshairType(Direction_t direction)
 
 static void M_RD_Change_ImprovedCollision()
 {
+    if (strict_mode)
+    {
+        return; // Disallow toggling in strict vanilla mode.
+    }
+
     improved_collision ^= 1;
 }
 
 static void M_RD_Change_WalkOverUnder()
 {
+    if (strict_mode)
+    {
+        return; // Disallow toggling in strict vanilla mode.
+    }
+
     over_under ^= 1;
 }
 
 static void M_RD_Change_Torque()
 {
+    if (strict_mode)
+    {
+        return; // Disallow toggling in strict vanilla mode.
+    }
+
     torque ^= 1;
 }
 
@@ -4986,6 +5141,11 @@ static void M_RD_Change_Bobbing()
 
 static void M_RD_Change_SSGBlast()
 {
+    if (strict_mode)
+    {
+        return; // Disallow toggling in strict vanilla mode.
+    }
+
     ssg_blast_enemies ^= 1;
 }
 
@@ -4996,6 +5156,11 @@ static void M_RD_Change_FloatPowerups(Direction_t direction)
 
 static void M_RD_Change_TossDrop()
 {
+    if (strict_mode)
+    {
+        return; // Disallow toggling in strict vanilla mode.
+    }
+
     toss_drop ^= 1;
 }
 
@@ -5030,6 +5195,11 @@ static void M_RD_Change_InfraGreenVisor()
 
 static void M_RD_Change_HorizontalAiming(Direction_t direction)
 {
+    if (strict_mode)
+    {
+        return; // Disallow toggling in strict vanilla mode.
+    }
+
     RD_Menu_SpinInt(&horizontal_autoaim, 0, 3, direction);
 }
 
@@ -5060,6 +5230,11 @@ static void M_RD_Change_LostSoulsQty()
 
 static void M_RD_Change_LostSoulsAgr()
 {
+    if (strict_mode)
+    {
+        return; // Disallow toggling in strict vanilla mode.
+    }
+
     agressive_lost_souls ^= 1;
 }
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -283,7 +283,7 @@ static void M_RD_Change_SwirlingLiquids();
 static void M_RD_Change_InvulSky();
 static void M_RD_Change_LinearSky();
 static void M_RD_Change_FlipCorpses();
-static void M_RD_Change_FlipWeapons();
+static void M_RD_Change_StrictMode();
 
 // Page 2
 static void M_RD_Change_ExtraPlayerFaces();
@@ -1295,8 +1295,8 @@ static MenuItem_t Gameplay1Items[] = {
     {ITT_SWITCH,  "Invulnerability affects sky:", "ytezpdbvjcnm jrhfibdftn yt,j:",  M_RD_Change_InvulSky,        0}, // Неуязвимость окрашивает небо
     {ITT_SWITCH,  "Sky drawing mode:",            "ht;bv jnhbcjdrb yt,f:",          M_RD_Change_LinearSky,       0}, // Режим отрисовки неба
     {ITT_SWITCH,  "Randomly mirrored corpses:",   "pthrfkmyjt jnhf;tybt nhegjd:",   M_RD_Change_FlipCorpses,     0}, // Зеркалирование трупов
-    {ITT_SWITCH,  "Flip weapons:",                "pthrfkmyjt jnhf;tybt jhe;bz:",   M_RD_Change_FlipWeapons,     0}, // Зеркальное отражение оружия
-    {ITT_EMPTY,   NULL,                           NULL,                             NULL,                        0},
+    {ITT_TITLE,   "Game mechanics",               "BUHJDFZ VT[FYBRF",               NULL,                        0}, // Игровая механика
+    {ITT_SWITCH,  "Strict vanilla mode:",         "cnhjuj jhbubyfkmysq ht;bv:",     M_RD_Change_StrictMode,      0}, // Строго оригинальный режим
     {ITT_SETMENU, NULL, /* Next Page > */         NULL,                             &Gameplay2Menu,              0}, // Далее >
     {ITT_SETMENU, NULL, /* < Last Page */         NULL,                             &Gameplay5Menu,              0}  // < Назад
 };
@@ -4028,9 +4028,9 @@ static void M_RD_Draw_Gameplay_1(void)
         RD_M_DrawTextSmallENG(randomly_flipcorpses ? RD_ON : RD_OFF, 231 + wide_delta, 115,
                               randomly_flipcorpses ? CR_GREEN : CR_DARKRED);
 
-        // Flip weapons
-        RD_M_DrawTextSmallENG(flip_weapons ? RD_ON : RD_OFF, 131 + wide_delta, 125,
-                             flip_weapons ? CR_GREEN : CR_DARKRED);
+        // Strict Vanilla mode
+        RD_M_DrawTextSmallENG(strict_mode ? RD_ON : RD_OFF, 178 + wide_delta, 135,
+                              strict_mode ? CR_GREEN : CR_DARKRED);
 
         //
         // Footer
@@ -4081,9 +4081,9 @@ static void M_RD_Draw_Gameplay_1(void)
         RD_M_DrawTextSmallRUS(randomly_flipcorpses ? RD_ON_RUS : RD_OFF_RUS, 255 + wide_delta, 115,
                               randomly_flipcorpses ? CR_GREEN : CR_DARKRED);
 
-        // Зеркальное отражение оружия
-        RD_M_DrawTextSmallRUS(flip_weapons ? RD_ON_RUS : RD_OFF_RUS, 259 + wide_delta, 125,
-                              flip_weapons ? CR_GREEN : CR_DARKRED);
+        // Строго оригинальный режим
+        RD_M_DrawTextSmallRUS(strict_mode ? RD_ON_RUS : RD_OFF_RUS, 242 + wide_delta, 135,
+                              strict_mode ? CR_GREEN : CR_DARKRED);
 
         //
         // Footer
@@ -4757,12 +4757,9 @@ static void M_RD_Change_FlipCorpses()
     randomly_flipcorpses ^= 1;
 }
 
-static void M_RD_Change_FlipWeapons()
+static void M_RD_Change_StrictMode()
 {
-    flip_weapons ^= 1;
-
-    // [JN] Skip weapon bobbing interpolation for next frame.
-    skippsprinterp = true;
+    strict_mode ^= 1;
 }
 
 //
@@ -5842,6 +5839,7 @@ static void M_RD_BackToDefaults_Recommended(int choice)
     linear_sky       = 1;
     randomly_flipcorpses = 1;
     flip_weapons     = 0;
+    strict_mode      = 0;
 
     // Gameplay: Status Bar
     sbar_colored        = 0;
@@ -6027,6 +6025,7 @@ static void M_RD_BackToDefaults_Original(int choice)
     linear_sky       = 0;
     randomly_flipcorpses = 0;
     flip_weapons     = 0;
+    strict_mode      = 1;
 
     // Gameplay: Status Bar
     sbar_colored        = 0;

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -274,6 +274,7 @@ static void M_RD_Draw_Gameplay_4();
 static void M_RD_Draw_Gameplay_5();
 
 // Page 1
+static void M_RD_Change_StrictMode();
 static void M_RD_Change_Brightmaps();
 static void M_RD_Change_FakeContrast();
 static void M_RD_Change_Translucency();
@@ -283,7 +284,6 @@ static void M_RD_Change_SwirlingLiquids();
 static void M_RD_Change_InvulSky();
 static void M_RD_Change_LinearSky();
 static void M_RD_Change_FlipCorpses();
-static void M_RD_Change_StrictMode();
 
 // Page 2
 static void M_RD_Change_ExtraPlayerFaces();
@@ -1285,6 +1285,8 @@ static const PageDescriptor_t GameplayPageDescriptor = {
 };
 
 static MenuItem_t Gameplay1Items[] = {
+    {ITT_TITLE,   "Game mechanics",               "BUHJDFZ VT[FYBRF",               NULL,                        0}, // Игровая механика
+    {ITT_SWITCH,  "Strict vanilla mode:",         "cnhjuj jhbubyfkmysq ht;bv:",     M_RD_Change_StrictMode,      0}, // Строго оригинальный режим
     {ITT_TITLE,   "Graphical",                    "uhfabrf",                        NULL,                        0}, // Графика
     {ITT_SWITCH,  "Brightmaps:",                  ",hfqnvfggbyu:",                  M_RD_Change_Brightmaps,      0}, // Брайтмаппинг
     {ITT_SWITCH,  "Fake contrast:",               "Bvbnfwbz rjynhfcnyjcnb:",        M_RD_Change_FakeContrast,    0}, // Имитация контрастности
@@ -1295,8 +1297,6 @@ static MenuItem_t Gameplay1Items[] = {
     {ITT_SWITCH,  "Invulnerability affects sky:", "ytezpdbvjcnm jrhfibdftn yt,j:",  M_RD_Change_InvulSky,        0}, // Неуязвимость окрашивает небо
     {ITT_SWITCH,  "Sky drawing mode:",            "ht;bv jnhbcjdrb yt,f:",          M_RD_Change_LinearSky,       0}, // Режим отрисовки неба
     {ITT_SWITCH,  "Randomly mirrored corpses:",   "pthrfkmyjt jnhf;tybt nhegjd:",   M_RD_Change_FlipCorpses,     0}, // Зеркалирование трупов
-    {ITT_TITLE,   "Game mechanics",               "BUHJDFZ VT[FYBRF",               NULL,                        0}, // Игровая механика
-    {ITT_SWITCH,  "Strict vanilla mode:",         "cnhjuj jhbubyfkmysq ht;bv:",     M_RD_Change_StrictMode,      0}, // Строго оригинальный режим
     {ITT_SETMENU, NULL, /* Next Page > */         NULL,                             &Gameplay2Menu,              0}, // Далее >
     {ITT_SETMENU, NULL, /* < Last Page */         NULL,                             &Gameplay5Menu,              0}  // < Назад
 };
@@ -3986,17 +3986,21 @@ static void M_RD_Draw_Gameplay_1(void)
 
     if (english_language)
     {
+        // Strict Vanilla mode
+        RD_M_DrawTextSmallENG(strict_mode ? RD_ON : RD_OFF, 178 + wide_delta, 35,
+                              strict_mode ? CR_GREEN : CR_DARKRED);
+
         // Brightmaps
-        RD_M_DrawTextSmallENG(brightmaps ? RD_ON : RD_OFF, 119 + wide_delta, 35,
+        RD_M_DrawTextSmallENG(brightmaps ? RD_ON : RD_OFF, 119 + wide_delta, 55,
                               brightmaps ? CR_GREEN : CR_DARKRED);
 
 
         // Fake contrast
-        RD_M_DrawTextSmallENG(fake_contrast ? RD_ON : RD_OFF,142 + wide_delta, 45,
+        RD_M_DrawTextSmallENG(fake_contrast ? RD_ON : RD_OFF,142 + wide_delta, 65,
                               fake_contrast ? CR_GREEN : CR_DARKRED);
 
         // Translucency
-        RD_M_DrawTextSmallENG(translucency ? RD_ON : RD_OFF, 138 + wide_delta, 55,
+        RD_M_DrawTextSmallENG(translucency ? RD_ON : RD_OFF, 138 + wide_delta, 75,
                               translucency ? CR_GREEN : CR_DARKRED);
 
         // Fuzz effect
@@ -4004,33 +4008,29 @@ static void M_RD_Draw_Gameplay_1(void)
                               improved_fuzz == 1 ? "Original (b&w)" :
                               improved_fuzz == 2 ? "Improved" :
                               improved_fuzz == 3 ? "Improved (b&w)" :
-                              "Translucent", 125 + wide_delta, 65,
+                              "Translucent", 125 + wide_delta, 85,
                               improved_fuzz > 0 ? CR_GREEN : CR_DARKRED);
 
         // Colored blood and corpses
         RD_M_DrawTextSmallENG(colored_blood == 1 ? "ON" :
                               colored_blood == 2 ? "ON+FUZZY" : "OFF",
-                              229 + wide_delta, 75, colored_blood ? CR_GREEN : CR_DARKRED);
+                              229 + wide_delta, 95, colored_blood ? CR_GREEN : CR_DARKRED);
 
         // Liquids animation
-        RD_M_DrawTextSmallENG(swirling_liquids ? "improved" : "original", 159 + wide_delta, 85,
+        RD_M_DrawTextSmallENG(swirling_liquids ? "improved" : "original", 159 + wide_delta, 105,
                               swirling_liquids ? CR_GREEN : CR_DARKRED);
 
         // Invulnerability affects sky
-        RD_M_DrawTextSmallENG(invul_sky ? RD_ON : RD_OFF, 237 + wide_delta, 95,
+        RD_M_DrawTextSmallENG(invul_sky ? RD_ON : RD_OFF, 237 + wide_delta, 115,
                              invul_sky ? CR_GREEN : CR_DARKRED);
 
         // Horizontally linear sky drawing
-        RD_M_DrawTextSmallENG(linear_sky ? "linear" : "original", 160 + wide_delta, 105,
+        RD_M_DrawTextSmallENG(linear_sky ? "linear" : "original", 160 + wide_delta, 125,
                              linear_sky ? CR_GREEN : CR_DARKRED);
 
         // Randomly mirrored corpses
-        RD_M_DrawTextSmallENG(randomly_flipcorpses ? RD_ON : RD_OFF, 231 + wide_delta, 115,
+        RD_M_DrawTextSmallENG(randomly_flipcorpses ? RD_ON : RD_OFF, 231 + wide_delta, 135,
                               randomly_flipcorpses ? CR_GREEN : CR_DARKRED);
-
-        // Strict Vanilla mode
-        RD_M_DrawTextSmallENG(strict_mode ? RD_ON : RD_OFF, 178 + wide_delta, 135,
-                              strict_mode ? CR_GREEN : CR_DARKRED);
 
         //
         // Footer
@@ -4040,16 +4040,20 @@ static void M_RD_Draw_Gameplay_1(void)
     }
     else
     {
+        // Строго оригинальный режим
+        RD_M_DrawTextSmallRUS(strict_mode ? RD_ON_RUS : RD_OFF_RUS, 242 + wide_delta, 35,
+                              strict_mode ? CR_GREEN : CR_DARKRED);
+
         // Брайтмаппинг
-        RD_M_DrawTextSmallRUS(brightmaps ? RD_ON_RUS : RD_OFF_RUS, 140 + wide_delta, 35,
+        RD_M_DrawTextSmallRUS(brightmaps ? RD_ON_RUS : RD_OFF_RUS, 140 + wide_delta, 55,
                               brightmaps ? CR_GREEN : CR_DARKRED);
 
         // Имитация контрастности
-        RD_M_DrawTextSmallRUS(fake_contrast ? RD_ON_RUS : RD_OFF_RUS, 217 + wide_delta, 45,
+        RD_M_DrawTextSmallRUS(fake_contrast ? RD_ON_RUS : RD_OFF_RUS, 217 + wide_delta, 65,
                               fake_contrast ? CR_GREEN : CR_DARKRED);
 
         // Прозрачность объектов
-        RD_M_DrawTextSmallRUS(translucency ? RD_ON_RUS : RD_OFF_RUS, 207 + wide_delta, 55,
+        RD_M_DrawTextSmallRUS(translucency ? RD_ON_RUS : RD_OFF_RUS, 207 + wide_delta, 75,
                               translucency ? CR_GREEN : CR_DARKRED);
 
         // Эффект шума
@@ -4057,33 +4061,29 @@ static void M_RD_Draw_Gameplay_1(void)
                               improved_fuzz == 1 ? "Jhbubyfkmysq (x*,)" :
                               improved_fuzz == 2 ? "Ekexityysq" :
                               improved_fuzz == 3 ? "Ekexityysq (x*,)" :
-                              "Ghjphfxysq", 134 + wide_delta, 65,
+                              "Ghjphfxysq", 134 + wide_delta, 85,
                               improved_fuzz > 0 ? CR_GREEN : CR_DARKRED);
 
         // Разноцветная кровь и трупы
         RD_M_DrawTextSmallRUS(colored_blood == 1 ? "drk" :
                               colored_blood == 2 ? "drk+iev" : "dsrk",
-                              242 + wide_delta, 75, colored_blood ? CR_GREEN : CR_DARKRED);
+                              242 + wide_delta, 95, colored_blood ? CR_GREEN : CR_DARKRED);
 
         // Анимация жидкостей
-        RD_M_DrawTextSmallRUS(swirling_liquids ? "ekexityyfz" : "jhbubyfkmyfz", 190 + wide_delta, 85,
+        RD_M_DrawTextSmallRUS(swirling_liquids ? "ekexityyfz" : "jhbubyfkmyfz", 190 + wide_delta, 105,
                               swirling_liquids ? CR_GREEN : CR_DARKRED);
 
         // Неуязвимость окрашивает небо
-        RD_M_DrawTextSmallRUS(invul_sky ? RD_ON_RUS : RD_OFF_RUS, 262 + wide_delta, 95,
+        RD_M_DrawTextSmallRUS(invul_sky ? RD_ON_RUS : RD_OFF_RUS, 262 + wide_delta, 115,
                               invul_sky ? CR_GREEN : CR_DARKRED);
 
         // Режим отрисовки неба
-        RD_M_DrawTextSmallRUS(linear_sky ? "kbytqysq" : "jhbubyfkmysq", 200 + wide_delta, 105,
+        RD_M_DrawTextSmallRUS(linear_sky ? "kbytqysq" : "jhbubyfkmysq", 200 + wide_delta, 125,
                               linear_sky ? CR_GREEN : CR_DARKRED);
 
         // Зеркальное отражение трупов
-        RD_M_DrawTextSmallRUS(randomly_flipcorpses ? RD_ON_RUS : RD_OFF_RUS, 255 + wide_delta, 115,
+        RD_M_DrawTextSmallRUS(randomly_flipcorpses ? RD_ON_RUS : RD_OFF_RUS, 255 + wide_delta, 135,
                               randomly_flipcorpses ? CR_GREEN : CR_DARKRED);
-
-        // Строго оригинальный режим
-        RD_M_DrawTextSmallRUS(strict_mode ? RD_ON_RUS : RD_OFF_RUS, 242 + wide_delta, 135,
-                              strict_mode ? CR_GREEN : CR_DARKRED);
 
         //
         // Footer
@@ -4709,6 +4709,11 @@ static void M_RD_Draw_Gameplay_5(void)
     }
 }
 
+static void M_RD_Change_StrictMode()
+{
+    strict_mode ^= 1;
+}
+
 static void M_RD_Change_Brightmaps()
 {
     brightmaps ^= 1;
@@ -4755,11 +4760,6 @@ static void M_RD_Change_LinearSky()
 static void M_RD_Change_FlipCorpses()
 {
     randomly_flipcorpses ^= 1;
-}
-
-static void M_RD_Change_StrictMode()
-{
-    strict_mode ^= 1;
 }
 
 //
@@ -5828,6 +5828,9 @@ static void M_RD_BackToDefaults_Recommended(int choice)
     mouse_threshold  = 10;
     novert           = 1;
 
+    // Gameplay: Game Mechanics
+    strict_mode      = 0;
+
     // Gameplay: Graphical
     brightmaps       = 1;
     fake_contrast    = 0;
@@ -5839,7 +5842,6 @@ static void M_RD_BackToDefaults_Recommended(int choice)
     linear_sky       = 1;
     randomly_flipcorpses = 1;
     flip_weapons     = 0;
-    strict_mode      = 0;
 
     // Gameplay: Status Bar
     sbar_colored        = 0;
@@ -6014,6 +6016,9 @@ static void M_RD_BackToDefaults_Original(int choice)
     mouse_threshold    = 10;
     novert             = 1;
 
+    // Gameplay: Game Mechanics
+    strict_mode      = 1;
+
     // Gameplay: Graphical
     brightmaps       = 0;
     fake_contrast    = 1;
@@ -6025,7 +6030,6 @@ static void M_RD_BackToDefaults_Original(int choice)
     linear_sky       = 0;
     randomly_flipcorpses = 0;
     flip_weapons     = 0;
-    strict_mode      = 1;
 
     // Gameplay: Status Bar
     sbar_colored        = 0;

--- a/src/doom/p_enemy.c
+++ b/src/doom/p_enemy.c
@@ -185,7 +185,7 @@ boolean P_CheckMeleeRange (mobj_t *actor)
     }
 
     // [crispy] height check for melee attacks (from Hexen)
-    if (singleplayer && !vanillaparm && over_under && pl->player)
+    if (singleplayer && over_under && pl->player && !strict_mode && !vanillaparm)
     {
         // [crispy] Target is higher than the attacker
         if (pl->z > actor->z + actor->height)
@@ -353,7 +353,7 @@ static boolean P_Move (mobj_t*	actor)
         //
         // Do NOT simply return false 1/4th of the time (causes monsters to
         // back out when they shouldn't, and creates secondary stickiness).
-        if (improved_collision && singleplayer && !vanillaparm)
+        if (singleplayer && improved_collision && !strict_mode && !vanillaparm)
         {
             line_t *blockline = spechit[numspechit];
 
@@ -735,7 +735,7 @@ void A_Look (mobj_t *actor)
     // [JN] Original id Software's idea: 
     // If a monster yells at a player, it will 
     // alert other monsters to the player.
-    if (singleplayer && !vanillaparm && noise_alert_sfx)
+    if (singleplayer && noise_alert_sfx && !strict_mode && !vanillaparm)
     {
         P_NoiseAlert (actor->target, actor);
     }
@@ -1163,7 +1163,7 @@ void A_BruisAttack (mobj_t *actor)
 
     // [JN] Исправление оригинального бага с отсутствующим A_FaceTarget
     // https://doomwiki.org/wiki/Baron_attacks_a_monster_behind_him
-    if (singleplayer && !vanillaparm)
+    if (singleplayer && !strict_mode && !vanillaparm)
     {
         A_FaceTarget (actor);
     }
@@ -1505,7 +1505,7 @@ void A_Fire (mobj_t *actor)
     // of its (faulty) spawn sector and the target's actual sector.
     // Thanks to Quasar for his excellent analysis at
     // https://www.doomworld.com/vb/post/1297952
-    if (singleplayer && !vanillaparm)
+    if (singleplayer && !strict_mode && !vanillaparm)
     {
         actor->floorz = actor->subsector->sector->floorheight;
         actor->ceilingz = actor->subsector->sector->ceilingheight;
@@ -1531,7 +1531,7 @@ void A_VileTarget (mobj_t *actor)
     fog = P_SpawnMobj (actor->target->x,
                        // [JN] Fix fire spawned at wrong location.
                        // https://doomwiki.org/wiki/Arch-Vile_fire_spawned_at_the_wrong_location
-                       singleplayer ? actor->target->y : actor->target->x,
+                       singleplayer && !strict_mode && !vanillaparm ? actor->target->y : actor->target->x,
                        actor->target->z, MT_FIRE);
 
     actor->tracer = fog;
@@ -1720,7 +1720,7 @@ void A_PainShootSkull (mobj_t *actor, angle_t angle)
     mobj_t    *newmobj;
 
     // [JN] Optionally removed Lost Souls spawn limit.
-    if (!unlimited_lost_souls || !singleplayer || vanillaparm)
+    if (!singleplayer || !unlimited_lost_souls || vanillaparm)
     {
         // Count total number of skull currently on the level.
         int count = 0;
@@ -1757,7 +1757,7 @@ void A_PainShootSkull (mobj_t *actor, angle_t angle)
     // [DOOM Retro] Check whether the Lost Soul is being fired through a 1-sided
     // wall or an impassible line, or a "monsters can't cross" line.
     // If it is, then we don't allow the spawn.
-    if (singleplayer)
+    if (singleplayer && !strict_mode && !vanillaparm)
     {
         if (P_CheckLineSide(actor, x, y))
         {
@@ -1772,7 +1772,7 @@ void A_PainShootSkull (mobj_t *actor, angle_t angle)
     // [DOOM Retro] Check to see if the new Lost Soul's z value is above the
     // ceiling of its new sector, or below the floor. If so, kill it.
     || ((newmobj->z > newmobj->subsector->sector->ceilingheight - newmobj->height
-    || newmobj->z < newmobj->subsector->sector->floorheight) && singleplayer))
+    || newmobj->z < newmobj->subsector->sector->floorheight) && singleplayer && !strict_mode && !vanillaparm))
     {
         // kill it immediately
         P_DamageMobj (newmobj,actor,actor,10000);	

--- a/src/doom/p_floor.c
+++ b/src/doom/p_floor.c
@@ -82,10 +82,10 @@ const result_e T_MovePlane (sector_t *sector, const fixed_t speed, fixed_t dest,
 
             case 1:
             // [JN] Don't allow platform floor go through the ceiling.
-            if (singleplayer)
+            if (singleplayer && !strict_mode && !vanillaparm)
             {
                 dest = dest < sector->ceilingheight ?
-                    dest : sector->ceilingheight;
+                       dest : sector->ceilingheight;
             }
 
             // UP
@@ -100,7 +100,7 @@ const result_e T_MovePlane (sector_t *sector, const fixed_t speed, fixed_t dest,
                     P_ChangeSector(sector,crush);
                     // [JN] Crush everyone to death. 
                     // Special fix for E2M4 and probably other maps.
-                    if (singleplayer)
+                    if (singleplayer && !strict_mode && !vanillaparm)
                     return crushed;
                 }
                 return pastdest;

--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -511,7 +511,7 @@ void P_TouchSpecialThing (const mobj_t *special, const mobj_t *toucher)
             P_GiveArmor (player, 2);
             // [JN] Force to upgrade armor type to blue, to fix keeping
             // green armor while player have 200% armor points (from DOOM Retro).
-            if (singleplayer && !vanillaparm)
+            if (singleplayer && !strict_mode && !vanillaparm)
             {
                 player->armortype = 2;
             }
@@ -641,7 +641,7 @@ void P_TouchSpecialThing (const mobj_t *special, const mobj_t *toucher)
             // [JN] Allow to pickup automap if player already have it,
             // to make 100% items possible on levels with few automaps. 
             // Notable example: MAP27 of Hell on Earth.
-            if (singleplayer && !vanillaparm)
+            if (singleplayer && !strict_mode && !vanillaparm)
             {
                 P_GivePower (player, pw_allmap);
             }
@@ -977,7 +977,7 @@ static void P_KillMobj (const mobj_t *source, mobj_t *target)
     }
 
     // [JN] Dropped items tossing feature (from DOOM Retro).
-    if (toss_drop && singleplayer && !vanillaparm)
+    if (singleplayer && toss_drop && !strict_mode && !vanillaparm)
     {
         mo = P_SpawnMobj(target->x ,target->y, target->floorz
                                              + target->height
@@ -1139,11 +1139,11 @@ void P_DamageMobj (mobj_t *target, const mobj_t *inflictor, mobj_t *source, int 
     {
         // [crispy] the lethal pellet of a point-blank SSG blast
         // gets an extra damage boost for the occasional gib chance
-        if (ssg_blast_enemies && !vanillaparm)
+        if (singleplayer && ssg_blast_enemies && !strict_mode && !vanillaparm)
         {
             extern boolean P_CheckMeleeRange (mobj_t *actor);
 
-            if (singleplayer && source && source->player
+            if (source && source->player
             && source->player->readyweapon == wp_supershotgun
             && target->info->xdeathstate && P_CheckMeleeRange(target) && damage >= 10)
             {
@@ -1157,7 +1157,7 @@ void P_DamageMobj (mobj_t *target, const mobj_t *inflictor, mobj_t *source, int 
 
     // [JN] Fix bug: https://doomwiki.org/wiki/Lost_soul_charging_backwards
     // Thanks AXDOOMER for this fix!
-    if (singleplayer && agressive_lost_souls && !vanillaparm)
+    if (singleplayer && agressive_lost_souls && !strict_mode && !vanillaparm)
     {
         if (P_Random () < target->info->painchance)
         {

--- a/src/doom/p_local.h
+++ b/src/doom/p_local.h
@@ -346,7 +346,7 @@ void P_UseLines (const player_t *player);
 // -----------------------------------------------------------------------------
 
 // Extended MAXINTERCEPTS, to allow for intercepts overrun emulation.
-#define MAXINTERCEPTS_ORIGINAL  128*16 // [JN] Лимит шестнадцатикратно умножен
+#define MAXINTERCEPTS_ORIGINAL  128
 #define MAXINTERCEPTS           (MAXINTERCEPTS_ORIGINAL + 61)
 #define PT_ADDLINES             1
 #define PT_ADDTHINGS            2
@@ -372,7 +372,6 @@ typedef struct
 
 typedef boolean (*traverser_t) (intercept_t *in);
 
-extern intercept_t  intercepts[MAXINTERCEPTS];
 extern intercept_t *intercept_p;
 extern divline_t    trace;
 extern fixed_t      opentop;

--- a/src/doom/p_map.c
+++ b/src/doom/p_map.c
@@ -333,7 +333,7 @@ static boolean PIT_CheckThing (mobj_t *thing)
     if (tmthing->flags & MF_SKULLFLY)
     {
         // [crispy] check if attacking skull flies over player
-        if (singleplayer && !vanillaparm && over_under && thing->player)
+        if (singleplayer && over_under && thing->player && !strict_mode && !vanillaparm)
         {
             if (tmthing->z > thing->z + thing->height)
             {
@@ -348,7 +348,7 @@ static boolean PIT_CheckThing (mobj_t *thing)
         // [JN] Fix bug: https://doomwiki.org/wiki/Lost_soul_colliding_with_items
         // Thanks AXDOOMER for this fix!
 
-        if (!singleplayer || !agressive_lost_souls || vanillaparm)
+        if (!singleplayer || !agressive_lost_souls || strict_mode || vanillaparm)
         {
             tmthing->flags &= ~MF_SKULLFLY;
             tmthing->momx = tmthing->momy = tmthing->momz = 0;
@@ -360,7 +360,7 @@ static boolean PIT_CheckThing (mobj_t *thing)
     }
     
     // [JN] Torque: make sliding corpses passable
-    if (singleplayer && !vanillaparm && torque && tmthing->intflags & MIF_FALLING)
+    if (singleplayer && torque && tmthing->intflags & MIF_FALLING && !strict_mode && !vanillaparm)
     {
         return true;
     }
@@ -430,7 +430,7 @@ static boolean PIT_CheckThing (mobj_t *thing)
         return !solid;
     }
 
-    if (singleplayer && !vanillaparm)
+    if (singleplayer && !strict_mode && !vanillaparm)
     {
         if (over_under)
         {
@@ -899,7 +899,7 @@ static const boolean P_ThingHeightClip (mobj_t* thing)
         // [JN] Update player's view when on moving platform.
         // Idea by Brad Harding, code by Fabian Greffrath.
         // Thanks, colleagues! (02.04.2018)
-        if (singleplayer && !vanillaparm && thing->player
+        if (singleplayer && !strict_mode && !vanillaparm && thing->player
         && thing->subsector->sector == movingsector)
         {
             P_CalcHeight (thing->player, true);
@@ -1000,8 +1000,9 @@ static boolean PTR_SlideTraverse (intercept_t *in)
     li = in->d.line;
 
     // [JN] Treat two sided linedefs as single sided for smooth sliding.
-    if (li->flags & ML_BLOCKING && li->flags & ML_TWOSIDED
-    && improved_collision && singleplayer && !vanillaparm)
+    if (singleplayer && improved_collision && 
+    li->flags & ML_BLOCKING && li->flags & ML_TWOSIDED
+    && !strict_mode && !vanillaparm)
     {
         goto isblocking;
     }
@@ -1550,7 +1551,7 @@ void P_LineAttack (mobj_t *t1, angle_t angle, int64_t distance,
     // [JN] Extend range so puffs may appear in long distances of hitscan attacks.
     // No damage will be dealed if range is greater than original MISSILERANGE,
     // (see PTR_ShootTraverse). Only for player, not for monsters. 
-    if (t1->player && distance >= MISSILERANGE && singleplayer && !vanillaparm)
+    if (singleplayer && t1->player && distance >= MISSILERANGE && !strict_mode && !vanillaparm)
     {
         distance = INT_MAX;
     }
@@ -1864,7 +1865,7 @@ boolean PIT_ChangeSector (mobj_t *thing)
 
         // spray blood in a random direction
 
-        if (thing->type == MT_BARREL && singleplayer && !vanillaparm)
+        if (singleplayer && thing->type == MT_BARREL && !strict_mode && !vanillaparm)
         {
             // [JN] Barrel should not bleed by crushed damage
             return true;

--- a/src/doom/p_maputl.c
+++ b/src/doom/p_maputl.c
@@ -73,7 +73,7 @@ const fixed_t P_ApproxDistanceZ (fixed_t dx, fixed_t dy, fixed_t dz)
 
 const fixed_t P_InterceptVector (const divline_t *v2, const divline_t *v1)
 {
-    if (singleplayer)
+    if (singleplayer && !strict_mode && !vanillaparm)
     {
         // [JN] cph - no precision/overflow problems
         const int64_t den = ((int64_t)v1->dy * v2->dx - (int64_t)v1->dx * v2->dy) >> 16;
@@ -424,7 +424,7 @@ const boolean P_BlockThingsIterator (int x, int y, boolean (*func)(mobj_t*))
     // [JN] Blockmap bug fix - add other mobjs from surrounding blocks that overlap this one.
     // The fix is written by Terry Hearst, thank you very much!
     // Fixes: http://doom2.net/doom2/research/things.html
-    if (improved_collision && singleplayer && !vanillaparm)
+    if (singleplayer && improved_collision && !strict_mode && !vanillaparm)
     {
         // Unwrapped for least number of bounding box checks
         // (-1, -1)

--- a/src/doom/p_maputl.c
+++ b/src/doom/p_maputl.c
@@ -22,6 +22,7 @@
 //
 
 
+#include "i_system.h"
 #include "m_bbox.h"
 #include "doomstat.h"
 #include "p_local.h"
@@ -531,9 +532,29 @@ const boolean P_BlockThingsIterator (int x, int y, boolean (*func)(mobj_t*))
 //
 // =============================================================================
 
-intercept_t  intercepts[MAXINTERCEPTS];
-intercept_t *intercept_p;
-divline_t    trace;
+static intercept_t *intercepts; // [crispy] remove INTERCEPTS limit
+intercept_t        *intercept_p;
+divline_t           trace;
+
+static void InterceptsOverrun (int num_intercepts, intercept_t *intercept);
+
+// -----------------------------------------------------------------------------
+// [crispy] remove INTERCEPTS limit
+// taken from PrBoom+/src/p_maputl.c:422-433
+// -----------------------------------------------------------------------------
+
+static void check_intercept (void)
+{
+	static size_t num_intercepts;
+	const size_t offset = intercept_p - intercepts;
+
+	if (offset >= num_intercepts)
+	{
+		num_intercepts = num_intercepts ? num_intercepts * 2 : MAXINTERCEPTS_ORIGINAL;
+		intercepts = I_Realloc(intercepts, sizeof(*intercepts) * num_intercepts);
+		intercept_p = intercepts + offset;
+	}
+}
 
 // -----------------------------------------------------------------------------
 // PIT_AddLineIntercepts.
@@ -579,16 +600,28 @@ static boolean PIT_AddLineIntercepts (line_t *ld)
         return true;  // behind source
     }
 
+    check_intercept(); // [crispy] remove INTERCEPTS limit
     intercept_p->frac = frac;
     intercept_p->isaline = true;
     intercept_p->d.line = ld;
-    intercept_p++;
-
+    InterceptsOverrun(intercept_p - intercepts, intercept_p);
     // [crispy] & [JN] Intercepts overflow guard.
-    if (intercept_p - intercepts == MAXINTERCEPTS + 1)
+    if (intercept_p - intercepts == MAXINTERCEPTS_ORIGINAL + 1)
     {
-        return false;
+        if (singleplayer && !strict_mode && !vanillaparm)
+        {
+            // [JN] Do not trigger overflow.
+            return false;
+        }
+        else
+        {
+            // [crispy] print a warning
+            fprintf(stderr, english_language ?
+                    "PIT_AddThingIntercepts: Triggered INTERCEPTS overflow!\n" :
+                    "PIT_AddThingIntercepts: произошло переполнение INTERCEPTS!\n");
+        }
     }
+    intercept_p++;
 
     return true;  // continue
 }
@@ -643,16 +676,29 @@ static boolean PIT_AddThingIntercepts (mobj_t *thing)
         return true;  // behind source
     }
 
+    check_intercept(); // [crispy] remove INTERCEPTS limit
     intercept_p->frac = frac;
     intercept_p->isaline = false;
     intercept_p->d.thing = thing;
-    intercept_p++;
-
+    InterceptsOverrun(intercept_p - intercepts, intercept_p);
     // [crispy] & [JN] Intercepts overflow guard.
-    if (intercept_p - intercepts == MAXINTERCEPTS + 1)
+    if (intercept_p - intercepts == MAXINTERCEPTS_ORIGINAL + 1)
     {
-        return false;
+        if (singleplayer && !strict_mode && !vanillaparm)
+        {
+            // [JN] Do not trigger overflow.
+            return false;
+        }
+        else
+        {
+            // [crispy] print a warning
+            fprintf(stderr, english_language ?
+                    "PIT_AddThingIntercepts: Triggered INTERCEPTS overflow!\n" :
+                    "PIT_AddThingIntercepts: произошло переполнение INTERCEPTS!\n");
+        }
     }
+
+    intercept_p++;
 
     return true;  // keep going
 }
@@ -687,6 +733,133 @@ static boolean P_TraverseIntercepts (const traverser_t func, const fixed_t maxfr
       in->frac = INT_MAX;
     }
     return true;            // everything was traversed
+}
+
+extern fixed_t bulletslope;
+
+// Intercepts Overrun emulation, from PrBoom-plus.
+// Thanks to Andrey Budko (entryway) for researching this and his 
+// implementation of Intercepts Overrun emulation in PrBoom-plus
+// which this is based on.
+
+typedef struct
+{
+    int len;
+    void *addr;
+    boolean int16_array;
+} intercepts_overrun_t;
+
+// Intercepts memory table.  This is where various variables are located
+// in memory in Vanilla Doom.  When the intercepts table overflows, we
+// need to write to them.
+//
+// Almost all of the values to overwrite are 32-bit integers, except for
+// playerstarts, which is effectively an array of 16-bit integers and
+// must be treated differently.
+
+static intercepts_overrun_t intercepts_overrun[] =
+{
+    {4,   NULL,                          false},
+    {4,   NULL, /* &earlyout, */         false},
+    {4,   NULL, /* &intercept_p, */      false},
+    {4,   &lowfloor,                     false},
+    {4,   &openbottom,                   false},
+    {4,   &opentop,                      false},
+    {4,   &openrange,                    false},
+    {4,   NULL,                          false},
+    {120, NULL, /* &activeplats, */      false},
+    {8,   NULL,                          false},
+    {4,   &bulletslope,                  false},
+    {4,   NULL, /* &swingx, */           false},
+    {4,   NULL, /* &swingy, */           false},
+    {4,   NULL,                          false},
+    {40,  &playerstarts,                 true},
+    {4,   NULL, /* &blocklinks, */       false},
+    {4,   &bmapwidth,                    false},
+    {4,   NULL, /* &blockmap, */         false},
+    {4,   &bmaporgx,                     false},
+    {4,   &bmaporgy,                     false},
+    {4,   NULL, /* &blockmaplump, */     false},
+    {4,   &bmapheight,                   false},
+    {0,   NULL,                          false},
+};
+
+// -----------------------------------------------------------------------------
+// InterceptsMemoryOverrun
+// Overwrite a specific memory location with a value.
+// -----------------------------------------------------------------------------
+
+static void InterceptsMemoryOverrun (int location, int value)
+{
+    int i, offset;
+    int index;
+    void *addr;
+
+    i = 0;
+    offset = 0;
+
+    // Search down the array until we find the right entry
+
+    while (intercepts_overrun[i].len != 0)
+    {
+        if (offset + intercepts_overrun[i].len > location)
+        {
+            addr = intercepts_overrun[i].addr;
+
+            // Write the value to the memory location.
+            // 16-bit and 32-bit values are written differently.
+
+            if (addr != NULL)
+            {
+                if (intercepts_overrun[i].int16_array)
+                {
+                    index = (location - offset) / 2;
+                    ((short *) addr)[index] = value & 0xffff;
+                    ((short *) addr)[index + 1] = (value >> 16) & 0xffff;
+                }
+                else
+                {
+                    index = (location - offset) / 4;
+                    ((int *) addr)[index] = value;
+                }
+            }
+
+            break;
+        }
+
+        offset += intercepts_overrun[i].len;
+        ++i;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// InterceptsOverrun
+// Emulate overruns of the intercepts[] array.
+// -----------------------------------------------------------------------------
+
+static void InterceptsOverrun (int num_intercepts, intercept_t *intercept)
+{
+    int location;
+
+    if (num_intercepts <= MAXINTERCEPTS_ORIGINAL)
+    {
+        // No overrun
+
+        return;
+    }
+
+    location = (num_intercepts - MAXINTERCEPTS_ORIGINAL - 1) * 12;
+
+    // Overwrite memory that is overwritten in Vanilla Doom, using
+    // the values from the intercept structure.
+    //
+    // Note: the ->d.{thing,line} member should really have its
+    // address translated into the correct address value for 
+    // Vanilla Doom.
+
+    InterceptsMemoryOverrun(location, intercept->frac);
+    InterceptsMemoryOverrun(location + 4, intercept->isaline);
+    InterceptsMemoryOverrun(location + 8, (intptr_t) intercept->d.thing);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/doom/p_pspr.c
+++ b/src/doom/p_pspr.c
@@ -34,7 +34,7 @@
 #define WEAPONTOP       32*FRACUNIT
 
 
-static fixed_t bulletslope;
+fixed_t bulletslope;
 
 // -----------------------------------------------------------------------------
 // P_SetPsprite

--- a/src/doom/p_pspr.c
+++ b/src/doom/p_pspr.c
@@ -456,7 +456,7 @@ void A_Punch (mobj_t *mobj, player_t *player, pspdef_t *psp)
     slope = P_AimLineAttack (player->mo, angle, MELEERANGE);
 
     // [JN] Also accout vertical attack angles
-    if (singleplayer && !linetarget && mlook)
+    if (singleplayer && !linetarget && mlook && !strict_mode && !vanillaparm)
     {
         if (aspect_ratio >= 2)
         {
@@ -507,7 +507,7 @@ void A_Saw (mobj_t *mobj, player_t *player, pspdef_t *psp)
     slope = P_AimLineAttack (player->mo, angle, MELEERANGE+1);
 
     // [JN] Also accout vertical attack angles
-    if (singleplayer && !linetarget && mlook)
+    if (singleplayer && !linetarget && mlook && !strict_mode && !vanillaparm)
     {
         if (aspect_ratio >= 2)
         {
@@ -676,7 +676,7 @@ static void P_BulletSlope (mobj_t *mo)
     {
         // [JN] Optional horizontal aiming.
         if ((horizontal_autoaim == 0 || horizontal_autoaim == 3)
-        || !singleplayer || vanillaparm)
+        || !singleplayer || strict_mode || vanillaparm)
         {
             an += 1<<26;
             bulletslope = P_AimLineAttack (mo, an, 16*64*FRACUNIT);
@@ -689,7 +689,7 @@ static void P_BulletSlope (mobj_t *mo)
         }
 
         // [JN] Mouselook: also count vertical angles
-        if (singleplayer && !linetarget && mlook)
+        if (singleplayer && !linetarget && mlook && !strict_mode && !vanillaparm)
         {
             if (aspect_ratio >= 2)
             {

--- a/src/doom/p_sight.c
+++ b/src/doom/p_sight.c
@@ -45,7 +45,7 @@ static int P_DivlineSide (const fixed_t x, const fixed_t y, const divline_t *nod
     return
         !node->dx ? x == node->x ? 2 : x <= node->x ? node->dy > 0 : node->dy < 0 :
         // [JN] Fix https://doomwiki.org/wiki/Sleeping_shotgun_guy_in_MAP02_(Doom_II)
-        !node->dy ? (singleplayer && !vanillaparm ? y : x)  
+        !node->dy ? (singleplayer && !strict_mode && !vanillaparm ? y : x)  
                       == node->y ? 2 : y <= node->y ? node->dx < 0 : node->dx > 0 :
         (right = ((y - node->y) >> FRACBITS) * (node->dx >> FRACBITS)) <
         (left  = ((x - node->x) >> FRACBITS) * (node->dy >> FRACBITS)) ? 0 :

--- a/src/doom/p_telept.c
+++ b/src/doom/p_telept.c
@@ -97,7 +97,7 @@ const int EV_Teleport (const line_t *line, const int side, mobj_t *thing)
                 //
                 // [JN] Fix behavior, safe for demos.
                 // https://doomwiki.org/wiki/Final_Doom_teleporters_do_not_set_Z_coordinate
-                if (gameversion != exe_final || (singleplayer && !vanillaparm))
+                if (gameversion != exe_final || (singleplayer && !strict_mode && !vanillaparm))
                 {
                     thing->z = thing->floorz;
                 }

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -412,7 +412,7 @@ void P_PlayerThink (player_t *player)
         if (newweapon == wp_fist
         && player->weaponowned[wp_chainsaw]
         && !(player->readyweapon == wp_chainsaw
-        && (player->powers[pw_strength] || (singleplayer && !vanillaparm))))
+        && (player->powers[pw_strength] || (singleplayer && !strict_mode && !vanillaparm))))
         {
             newweapon = wp_chainsaw;
         }

--- a/src/jn.h
+++ b/src/jn.h
@@ -264,6 +264,9 @@ extern int linear_sky;
 extern int randomly_flipcorpses;
 extern int flip_weapons;
 
+// Gameplay: Game Mechanics
+extern int strict_mode;
+
 // Gameplay: Status Bar
 extern int extra_player_faces;
 extern int negative_health;

--- a/src/jn.h
+++ b/src/jn.h
@@ -252,6 +252,9 @@ extern int selective_puzzle_16; // SIGIL OF THE MAGUS
 // Gameplay feautures
 // -----------------------------------------------------------------------------
 
+// Gameplay: Game Mechanics
+extern int strict_mode;
+
 // Gameplay: Graphical
 extern int brightmaps;
 extern int fake_contrast;
@@ -263,9 +266,6 @@ extern int invul_sky;
 extern int linear_sky;
 extern int randomly_flipcorpses;
 extern int flip_weapons;
-
-// Gameplay: Game Mechanics
-extern int strict_mode;
 
 // Gameplay: Status Bar
 extern int extra_player_faces;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -603,6 +603,9 @@ static default_t defaults_list[] =
     CONFIG_VARIABLE_INT(mouse_y_invert),
     CONFIG_VARIABLE_INT(artiskip),
 
+    // Gameplay: Game Mechanics
+    CONFIG_VARIABLE_INT(strict_mode),
+
     // Gameplay: Graphical
     CONFIG_VARIABLE_INT(brightmaps),
     CONFIG_VARIABLE_INT(fake_contrast),
@@ -614,9 +617,6 @@ static default_t defaults_list[] =
     CONFIG_VARIABLE_INT(linear_sky),
     CONFIG_VARIABLE_INT(randomly_flipcorpses),
     CONFIG_VARIABLE_INT(flip_weapons),
-
-    // Gameplay: Game Mechanics
-    CONFIG_VARIABLE_INT(strict_mode),
 
     // Gameplay: Status Bar
     CONFIG_VARIABLE_INT(extra_player_faces),

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -615,6 +615,9 @@ static default_t defaults_list[] =
     CONFIG_VARIABLE_INT(randomly_flipcorpses),
     CONFIG_VARIABLE_INT(flip_weapons),
 
+    // Gameplay: Game Mechanics
+    CONFIG_VARIABLE_INT(strict_mode),
+
     // Gameplay: Status Bar
     CONFIG_VARIABLE_INT(extra_player_faces),
     CONFIG_VARIABLE_INT(negative_health),


### PR DESCRIPTION
There are tons of various, non-optional small game mechanics fixes. It is silly to make a tons of unclear switches, and in case of users want 100% vanilla mechanics, they is forced to use `-vanilla` parameter which is _"too conservative"_.

This feature should allow to get pure vanilla game mechanics while keeping all safe visual/audible/etc features.