### PR TITLE
restore statdump, remove some I_Error calls in i_video

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -71,14 +71,15 @@ jobs:
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get full-upgrade --fix-missing
-          sudo apt-get install --fix-missing ${{ matrix.compiler.name }} ninja-build cmake libsdl2-dev libsdl2-net-dev libsdl2-mixer-dev libpng-dev libsamplerate-dev
+          sudo apt-get install --fix-missing ${{ matrix.compiler.name }} gdb ninja-build cmake libsdl2-dev libsdl2-net-dev libsdl2-mixer-dev libpng-dev libsamplerate-dev
 
       - uses: actions/checkout@v2
 
       - name: Configure
         id: configure
+        # -D BUILD_PORTABLE=ON for tests on linux without install
         run: |
-          cmake -G "Ninja" -D BUILD_VERSION_OVERWRITE="5.x.x" -D FORCE_GIT_HASH_SUFFIX=ON -D CMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build
+          cmake -G "Ninja" -D BUILD_VERSION_OVERWRITE="5.x.x" -D FORCE_GIT_HASH_SUFFIX=ON -D CMAKE_BUILD_TYPE=RelWithDebInfo -D BUILD_PORTABLE=ON -S . -B build
           sha_short=$(echo ${{ github.sha }} | cut -c1-7)
           echo "::set-output name=sha_short::$sha_short"
 
@@ -87,8 +88,16 @@ jobs:
           export MAKEFLAGS=--keep-going
           cmake --build build --parallel 2
 
-      - name: Test
-        if: ${{ matrix.os.name == 'Windows' }} # Linux runners have no video device
+      - name: Test Windows
+        if: ${{ matrix.os.name == 'Windows' }}
+        run: |
+          cd build
+          ctest --output-on-failure
+
+      - name: Test Linux
+        if: ${{ matrix.os.name == 'Linux' }}
+        env:
+          SDL_VIDEODRIVER: dummy
         run: |
           cd build
           ctest --output-on-failure

--- a/src/doom/CMakeLists.txt
+++ b/src/doom/CMakeLists.txt
@@ -62,6 +62,7 @@ if(COMPILE_DOOM)
                 r_things.c
                 s_sound.c       s_sound.h
                 sounds.c        sounds.h
+                statdump.c      statdump.h
                 st_bar.c        st_bar.h
                 wi_stuff.c      wi_stuff.h
     )

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -77,6 +77,7 @@
 #include "am_map.h"         // [JN] AM_initColors();
 #include "ct_chat.h"
 #include "jn.h"
+#include "statdump.h"
 
 #include "git_info.h"
 
@@ -3427,6 +3428,14 @@ void D_DoomMain (void)
     AM_initColors();
     AM_initPics();
     AM_initMarksColor(automap_mark_color);
+
+    if (M_CheckParmWithArgs("-statdump", 1))
+    {
+        I_AtExit(StatDump, true);
+        DEH_printf(english_language ?
+                   "External statistics registered.\n" :
+                   "Регистрация внешней статистики.\n");
+    }
 
     //!
     // @arg <x>

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -50,6 +50,7 @@
 #include "g_game.h"
 #include "ct_chat.h"
 #include "jn.h"
+#include "statdump.h"
 
 #define MAXPLMOVE       (forwardmove[1]) 
 #define TURBOTHRESHOLD  0x32
@@ -1709,6 +1710,12 @@ void G_DoCompleted (void)
 
     gamestate = GS_INTERMISSION; 
     automapactive = false; 
+
+    // [crispy] no statdump output for ExM8
+    if (gamemode == commercial || gamemap != 8)
+    {
+    StatCopy(&wminfo);
+    }
 
     WI_Start (&wminfo); 
 } 

--- a/src/doom/statdump.c
+++ b/src/doom/statdump.c
@@ -1,0 +1,358 @@
+ /*
+
+ Copyright(C) 2005-2014 Simon Howard
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ --
+
+ Functions for presenting the information captured from the statistics
+ buffer to a file.
+
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "doomdef.h"
+#include "d_mode.h"
+#include "m_argv.h"
+#include "statdump.h"
+#include "jn.h"
+
+/* Par times for E1M1-E1M9. */
+static const int doom1_par_times[] =
+{
+    30, 75, 120, 90, 165, 180, 180, 30, 165,
+};
+
+/* Par times for MAP01-MAP09. */
+static const int doom2_par_times[] =
+{
+    30, 90, 120, 120, 90, 150, 120, 120, 270,
+};
+
+/* Player colors. */
+static const char *player_colors[] =
+{
+    "Green", "Indigo", "Brown", "Red"
+};
+
+// Array of end-of-level statistics that have been captured.
+
+#define MAX_CAPTURES 32
+static wbstartstruct_t captured_stats[MAX_CAPTURES];
+static int num_captured_stats = 0;
+
+static GameMission_t discovered_gamemission = none;
+
+/* Try to work out whether this is a Doom 1 or Doom 2 game, by looking
+ * at the episode and map, and the par times.  This is used to decide
+ * how to format the level name.  Unfortunately, in some cases it is
+ * impossible to determine whether this is Doom 1 or Doom 2. */
+
+static void DiscoverGamemode(wbstartstruct_t *stats, int num_stats)
+{
+    int partime;
+    int level;
+    int i;
+
+    if (discovered_gamemission != none)
+    {
+        return;
+    }
+
+    for (i=0; i<num_stats; ++i)
+    {
+        level = stats[i].last;
+
+        /* If episode 2, 3 or 4, this is Doom 1. */
+
+        if (stats[i].epsd > 0)
+        {
+            discovered_gamemission = doom;
+            return;
+        }
+
+        /* This is episode 1.  If this is level 10 or higher,
+           it must be Doom 2. */
+
+        if (level >= 9)
+        {
+            discovered_gamemission = doom2;
+            return;
+        }
+
+        /* Try to work out if this is Doom 1 or Doom 2 by looking
+           at the par time. */
+
+        partime = stats[i].partime;
+
+        if (partime == doom1_par_times[level] * TICRATE
+         && partime != doom2_par_times[level] * TICRATE)
+        {
+            discovered_gamemission = doom;
+            return;
+        }
+
+        if (partime != doom1_par_times[level] * TICRATE
+         && partime == doom2_par_times[level] * TICRATE)
+        {
+            discovered_gamemission = doom2;
+            return;
+        }
+    }
+}
+
+/* Returns the number of players active in the given stats buffer. */
+
+static int GetNumPlayers(wbstartstruct_t *stats)
+{
+    int i;
+    int num_players = 0;
+
+    for (i=0; i<MAXPLAYERS; ++i)
+    {
+        if (stats->plyr[i].in)
+        {
+            ++num_players;
+        }
+    }
+
+    return num_players;
+}
+
+static void PrintBanner(FILE *stream)
+{
+    fprintf(stream, "===========================================\n");
+}
+
+static void PrintPercentage(FILE *stream, int amount, int total)
+{
+    if (total == 0)
+    {
+        fprintf(stream, "0");
+    }
+    else
+    {
+        fprintf(stream, "%i / %i", amount, total);
+
+        // statdump.exe is a 16-bit program, so very occasionally an
+        // integer overflow can occur when doing this calculation with
+        // a large value. Therefore, cast to short to give the same
+        // output.
+
+        fprintf(stream, " (%i%%)", (short) (amount * 100) / total);
+    }
+}
+
+/* Display statistics for a single player. */
+
+static void PrintPlayerStats(FILE *stream, wbstartstruct_t *stats,
+        int player_num)
+{
+    wbplayerstruct_t *player = &stats->plyr[player_num];
+
+    fprintf(stream, "Player %i (%s):\n",
+                    player_num + 1, player_colors[player_num]);
+
+    /* Kills percentage */
+
+    fprintf(stream, "\tKills: ");
+    PrintPercentage(stream, player->skills, stats->maxkills);
+    fprintf(stream, "\n");
+
+    /* Items percentage */
+
+    fprintf(stream, "\tItems: ");
+    PrintPercentage(stream, player->sitems, stats->maxitems);
+    fprintf(stream, "\n");
+
+    /* Secrets percentage */
+
+    fprintf(stream, "\tSecrets: ");
+    PrintPercentage(stream, player->ssecret, stats->maxsecret);
+    fprintf(stream, "\n");
+}
+
+/* Frags table for multiplayer games. */
+
+static void PrintFragsTable(FILE *stream, wbstartstruct_t *stats)
+{
+    int x, y;
+
+    fprintf(stream, "Frags:\n");
+
+    /* Print header */
+
+    fprintf(stream, "\t\t");
+
+    for (x=0; x<MAXPLAYERS; ++x)
+    {
+
+        if (!stats->plyr[x].in)
+        {
+            continue;
+        }
+
+        fprintf(stream, "%s\t", player_colors[x]);
+    }
+
+    fprintf(stream, "\n");
+
+    fprintf(stream, "\t\t-------------------------------- VICTIMS\n");
+
+    /* Print table */
+
+    for (y=0; y<MAXPLAYERS; ++y)
+    {
+        if (!stats->plyr[y].in)
+        {
+            continue;
+        }
+
+        fprintf(stream, "\t%s\t|", player_colors[y]);
+
+        for (x=0; x<MAXPLAYERS; ++x)
+        {
+            if (!stats->plyr[x].in)
+            {
+                continue;
+            }
+
+            fprintf(stream, "%i\t", stats->plyr[y].frags[x]);
+        }
+
+        fprintf(stream, "\n");
+    }
+
+    fprintf(stream, "\t\t|\n");
+    fprintf(stream, "\t     KILLERS\n");
+}
+
+/* Displays the level name: MAPxy or ExMy, depending on game mode. */
+
+static void PrintLevelName(FILE *stream, int episode, int level)
+{
+    PrintBanner(stream);
+
+    switch (discovered_gamemission)
+    {
+
+        case doom:
+            fprintf(stream, "E%iM%i\n", episode + 1, level + 1);
+            break;
+        case doom2:
+            fprintf(stream, "MAP%02i\n", level + 1);
+            break;
+        default:
+        case none:
+            fprintf(stream, "E%iM%i / MAP%02i\n",
+                            episode + 1, level + 1, level + 1);
+            break;
+    }
+
+    PrintBanner(stream);
+}
+
+/* Print details of a statistics buffer to the given file. */
+
+static void PrintStats(FILE *stream, wbstartstruct_t *stats)
+{
+    int leveltime, partime;
+    int i;
+
+    PrintLevelName(stream, stats->epsd, stats->last);
+    fprintf(stream, "\n");
+
+    leveltime = stats->plyr[0].stime / TICRATE;
+    partime = stats->partime / TICRATE;
+    fprintf(stream, "Time: %i:%02i",
+                    leveltime / 60, leveltime % 60);
+    fprintf(stream, " (par: %i:%02i)\n",
+                    partime / 60, partime % 60);
+    fprintf(stream, "\n");
+
+    for (i=0; i<MAXPLAYERS; ++i)
+    {
+        if (stats->plyr[i].in)
+        {
+            PrintPlayerStats(stream, stats, i);
+        }
+    }
+
+    if (GetNumPlayers(stats) >= 2)
+    {
+        PrintFragsTable(stream, stats);
+    }
+
+    fprintf(stream, "\n");
+}
+
+void StatCopy(wbstartstruct_t *stats)
+{
+    if (M_ParmExists("-statdump") && num_captured_stats < MAX_CAPTURES)
+    {
+        memcpy(&captured_stats[num_captured_stats], stats,
+               sizeof(wbstartstruct_t));
+        ++num_captured_stats;
+    }
+}
+
+void StatDump(void)
+{
+    FILE *dumpfile;
+    int i;
+
+    //!
+    // @category compat
+    // @arg <filename>
+    //
+    // Dump statistics information to the specified file on the levels
+    // that were played. The output from this option matches the output
+    // from statdump.exe (see ctrlapi.zip in the /idgames archive).
+    //
+
+    i = M_CheckParmWithArgs("-statdump", 1);
+
+    if (i > 0)
+    {
+        printf("Statistics captured for %i level(s)\n", num_captured_stats);
+
+        // We actually know what the real gamemission is, but this has
+        // to match the output from statdump.exe.
+
+        DiscoverGamemode(captured_stats, num_captured_stats);
+
+        // Allow "-" as output file, for stdout.
+
+        if (strcmp(myargv[i + 1], "-") != 0)
+        {
+            dumpfile = fopen(myargv[i + 1], "w");
+        }
+        else
+        {
+            dumpfile = NULL;
+        }
+
+        for (i = 0; i < num_captured_stats; ++i)
+        {
+            PrintStats(dumpfile, &captured_stats[i]);
+        }
+
+        if (dumpfile != NULL)
+        {
+            fclose(dumpfile);
+        }
+    }
+}
+

--- a/src/doom/statdump.h
+++ b/src/doom/statdump.h
@@ -1,0 +1,23 @@
+ /*
+
+ Copyright(C) 2005-2014 Simon Howard
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ */
+
+#ifndef DOOM_STATDUMP_H
+#define DOOM_STATDUMP_H
+
+void StatCopy(wbstartstruct_t *stats);
+void StatDump(void);
+
+#endif /* #ifndef DOOM_STATDUMP_H */

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -689,7 +689,10 @@ static void LimitTextureSize(int *w_upscale, int *h_upscale)
     orig_h = *h_upscale;
 
     // Query renderer and limit to maximum texture dimensions of hardware:
-    SDL_GetRendererInfo(renderer, &rinfo);
+    if (SDL_GetRendererInfo(renderer, &rinfo) != 0)
+    {
+        return;
+    }
 
     while (*w_upscale * screenwidth > rinfo.max_texture_width)
     {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -689,11 +689,7 @@ static void LimitTextureSize(int *w_upscale, int *h_upscale)
     orig_h = *h_upscale;
 
     // Query renderer and limit to maximum texture dimensions of hardware:
-    if (SDL_GetRendererInfo(renderer, &rinfo) != 0)
-    {
-        I_Error("CreateUpscaledTexture: SDL_GetRendererInfo() call failed: %s",
-                SDL_GetError());
-    }
+    SDL_GetRendererInfo(renderer, &rinfo);
 
     while (*w_upscale * screenwidth > rinfo.max_texture_width)
     {
@@ -759,13 +755,7 @@ static void CreateUpscaledTexture(const boolean force)
     // Get the size of the renderer output. The units this gives us will be
     // real world pixels, which are not necessarily equivalent to the screen's
     // window size (because of highdpi).
-    if (SDL_GetRendererOutputSize(renderer, &w, &h) != 0)
-    {
-        I_Error(english_language ?
-                "Failed to get renderer output size: %s" :
-                "Невозможно выполнить рендеринг размера: %s",
-                SDL_GetError());
-    }
+    SDL_GetRendererOutputSize(renderer, &w, &h);
 
     // When the screen or window dimensions do not match the aspect ratio
     // of the texture, the rendered area is scaled down to fit. Calculate
@@ -1427,6 +1417,10 @@ static void SetVideoMode(void)
     // retina displays, especially when using small window sizes.
     window_flags |= SDL_WINDOW_ALLOW_HIGHDPI;
 
+    SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER,
+                            opengles_renderer ? "opengles2" : "direct3d",
+                            SDL_HINT_OVERRIDE);
+
 #ifdef _WIN32
     // [JN] Windows 11 idiocy. Indicate that window using OpenGL mode (while it's
     // a Direct3D in fact), so SDL texture will not be freezed upon vsync toggling.
@@ -1480,14 +1474,6 @@ static void SetVideoMode(void)
         screen = SDL_CreateWindow(NULL, window_border == 0 ? 0 : window_position_x,
                                         window_border == 0 ? 0 : window_position_y,
                                         w, h, window_flags);
-
-        if (screen == NULL)
-        {
-            I_Error(english_language ?
-                    "Error creating window for video startup: %s" :
-                    "Ошибка создания окна для видео-загрузки: %s",
-            SDL_GetError());
-        }
 
 #ifdef _WIN32
         DisableWinRound(screen);
@@ -1561,14 +1547,6 @@ static void SetVideoMode(void)
         {
             force_software_renderer = 1;
         }
-    }
-
-    if (renderer == NULL)
-    {
-        I_Error(english_language ?
-                "Error creating renderer for screen window: %s" :
-                "Ошибка создания рендеринга для окна: %s",
-                SDL_GetError());
     }
 
     // Important: Set the "logical size" of the rendering context. At the same

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1417,10 +1417,6 @@ static void SetVideoMode(void)
     // retina displays, especially when using small window sizes.
     window_flags |= SDL_WINDOW_ALLOW_HIGHDPI;
 
-    SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER,
-                            opengles_renderer ? "opengles2" : "direct3d",
-                            SDL_HINT_OVERRIDE);
-
 #ifdef _WIN32
     // [JN] Windows 11 idiocy. Indicate that window using OpenGL mode (while it's
     // a Direct3D in fact), so SDL texture will not be freezed upon vsync toggling.

--- a/src/m_argv.c
+++ b/src/m_argv.c
@@ -690,6 +690,12 @@ printf("  %-31s  %s\n", (keys), english_language ? (description_eng) : (descript
                       "Record or playback a demo without automatically quitting after either level exit or player respawn",
                       "Записать или проиграть демо без автоматического выхода после завершения уровня или возрождения игрока");
     }
+    if(RD_GameType == gt_Doom)
+    {
+        CLI_Parameter("-statdump <file>",
+                      "Dump statistics information of the levels that were played to the specified <file>. The output from this option matches the output from statdump.exe. If \"-\" provided as <file> argument, statistics will be printed to console",
+                      "Вывести статистическую информацию об уровнях, которые были воспроизведены, в указанный <file>. Выходные данные этого параметра совпадают с выходными данными из statdump.exe. Если в качестве аргумента <file> передан \"-\", статистика будет выведена в консоль");
+    }
     CLI_Parameter("-longtics",
                   "Record or playback a demo with high resolution turning",
                   "Записать или проиграть демо с высоким разрешением поворота");


### PR DESCRIPTION
> remove some I_Error calls in i_video

This allows the game to run when the environment variable SDL_VIDEODRIVER=dummy is set. Therefore, SDL does not create an empty window with the -nodraw option, which speeds up automatic testing, and also allows to run on systems without proper graphics (WSL).