### PR TITLE
Fix `sscanf_s` check, allow `sscanf_s` on Win x64

### DIFF
--- a/src/i_controller.c
+++ b/src/i_controller.c
@@ -557,7 +557,7 @@ void ControllerHandler_HandleLine(char* keyName, char *value, size_t valueSize)
     SDL_GameControllerAxis axis;
     axisOption_t axisOption;
 
-#if HAVE_DECL_SSCANF_S && !defined(_WIN32)
+#if HAVE_DECL_SSCANF_S && (!defined(_WIN32) || defined(_WIN64))
     if(sscanf_s(keyName, "%10[^_]_%20s", axisName, 11, axisOptionName, 21) != 2)
 #else
     if(sscanf(keyName, "%10[^_]_%20s", axisName, axisOptionName) != 2)


### PR DESCRIPTION
Forgot that `_WIN32` also exists on 64-bit Windows.
May still fail on WinXP 64, don't have one to test