### PR TITLE
Doom: extra rendering options

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
             shell: "msys2 {0}"
           -
             name: "Linux"
-            runner: "ubuntu-latest"
+            runner: "ubuntu-22.04"
             shell: "bash"
         arch:
           -

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ else()
     string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 endif()
 
-find_package(SDL2 2.0.4 REQUIRED)
+find_package(SDL2 2.0.16 REQUIRED)
 find_package(SDL2_mixer 2.0.2 REQUIRED)
 find_package(SDL2_net 2.0.0 REQUIRED)
 find_package(samplerate)

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -146,6 +146,7 @@ static void M_RD_Change_WindowBorder();
 static void M_RD_Change_WindowSize(Direction_t direction);
 static void M_RD_Change_WindowTitle();
 static void M_RD_Change_AlwaysOnTop();
+static void M_RD_Change_WindowAspectRatio();
 static void M_RD_Change_DiskIcon(Direction_t direction);
 static void M_RD_Change_Wiping(Direction_t direction);
 static void M_RD_Change_Screenshots();
@@ -724,20 +725,20 @@ static Menu_t Rendering1Menu = {
 };
 
 static MenuItem_t Rendering2Items[] = {
-    {ITT_TITLE,   "Window options",         "Yfcnhjqrb jryf",             NULL,                     0}, // Настройки окна
-    {ITT_SWITCH,  "Bordered window:",       "jryj c hfvrjq:",             M_RD_Change_WindowBorder, 0}, // Окно с рамкой
-    {ITT_LRFUNC,  "Window size:",           "hfpvth jryf:",               M_RD_Change_WindowSize,   0}, // Размер окна
-    {ITT_SWITCH,  "Window title:",          "pfujkjdjr jryf:",            M_RD_Change_WindowTitle,  0}, // Заголовок окна
-    {ITT_SWITCH,  "Always on top:",         "gjdth[ lheub[ jrjy:",        M_RD_Change_AlwaysOnTop,  0}, // Поверх других окон
-    {ITT_TITLE,   "Extra",                  "ljgjkybntkmyj",              NULL,                     0}, // Дополнительно
-    {ITT_LRFUNC,  "Show disk icon:",        "Jnj,hf;fnm pyfxjr lbcrtns:", M_RD_Change_DiskIcon,     0}, // Отображать значок дискеты
-    {ITT_LRFUNC,  "Screen wiping effect:",  "\'aatrn cvtys \'rhfyjd:",    M_RD_Change_Wiping,       0}, // Эффект смены экранов
-    {ITT_SWITCH,  "Screenshot format:",     "Ajhvfn crhbyijnjd:",         M_RD_Change_Screenshots,  0}, // Формат скриншотов
-    {ITT_SWITCH,  "Show ENDOOM screen:",    "Gjrfpsdfnm \'rhfy",          M_RD_Change_ENDOOM,       0}, // Показывать экран ENDOOM
-    {ITT_EMPTY,   NULL,                     NULL,                         NULL,                     0},
-    {ITT_EMPTY,   NULL,                     NULL,                         NULL,                     0},
-    {ITT_EMPTY,   NULL,                     NULL,                         NULL,                     0},
-    {ITT_SETMENU, NULL, /* < Prev Page > */ NULL,                         &Rendering1Menu,          0}  // < Назад
+    {ITT_TITLE,   "Window options",                "Yfcnhjqrb jryf",             NULL,                          0}, // Настройки окна
+    {ITT_SWITCH,  "Bordered window:",              "jryj c hfvrjq:",             M_RD_Change_WindowBorder,      0}, // Окно с рамкой
+    {ITT_LRFUNC,  "Window size:",                  "hfpvth jryf:",               M_RD_Change_WindowSize,        0}, // Размер окна
+    {ITT_SWITCH,  "Window title:",                 "pfujkjdjr jryf:",            M_RD_Change_WindowTitle,       0}, // Заголовок окна
+    {ITT_SWITCH,  "Always on top:",                "gjdth[ lheub[ jrjy:",        M_RD_Change_AlwaysOnTop,       0}, // Поверх других окон
+    {ITT_SWITCH,  "Preserve window aspect ratio:", "ghjgjhwbb jryf:",            M_RD_Change_WindowAspectRatio, 0}, // Пропорции окна
+    {ITT_TITLE,   "Extra",                         "ljgjkybntkmyj",              NULL,                          0}, // Дополнительно
+    {ITT_LRFUNC,  "Show disk icon:",               "Jnj,hf;fnm pyfxjr lbcrtns:", M_RD_Change_DiskIcon,          0}, // Отображать значок дискеты
+    {ITT_LRFUNC,  "Screen wiping effect:",         "\'aatrn cvtys \'rhfyjd:",    M_RD_Change_Wiping,            0}, // Эффект смены экранов
+    {ITT_SWITCH,  "Screenshot format:",            "Ajhvfn crhbyijnjd:",         M_RD_Change_Screenshots,       0}, // Формат скриншотов
+    {ITT_SWITCH,  "Show ENDOOM screen:",           "Gjrfpsdfnm \'rhfy",          M_RD_Change_ENDOOM,            0}, // Показывать экран ENDOOM
+    {ITT_EMPTY,   NULL,                            NULL,                         NULL,                          0},
+    {ITT_EMPTY,   NULL,                            NULL,                         NULL,                          0},
+    {ITT_SETMENU, NULL, /* < Prev Page > */        NULL,                         &Rendering1Menu,               0}  // < Назад
 };
 
 static Menu_t Rendering2Menu = {
@@ -1965,21 +1966,24 @@ static void M_RD_Draw_Rendering_2 (void)
         // Always on top
         RD_M_DrawTextSmallENG(window_ontop ? "on" : "off", 139 + wide_delta, 65, CR_NONE);
 
+        // Preserve window aspect ratio
+        RD_M_DrawTextSmallENG(aspect_ratio_correct ? "on" : "off", 246 + wide_delta, 75, CR_NONE);
+
         // Show disk icon
         RD_M_DrawTextSmallENG(show_diskicon == 1 ? "bottom" :
                               show_diskicon == 2 ? "top" :
-                              "off", 138 + wide_delta, 85, CR_NONE);
+                              "off", 138 + wide_delta, 95, CR_NONE);
 
         // Screen wiping effect
         RD_M_DrawTextSmallENG(screen_wiping == 1 ? "standard" :
                               screen_wiping == 2 ? "loading" :
-                              "off", 187 + wide_delta, 95, CR_NONE);
+                              "off", 187 + wide_delta, 105, CR_NONE);
 
         // Screenshot format
-        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 174 + wide_delta, 105, CR_NONE);
+        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 174 + wide_delta, 115, CR_NONE);
 
         // Show ENDOOM screen
-        RD_M_DrawTextSmallENG(show_endoom ? "on" : "off", 179 + wide_delta, 115, CR_NONE);
+        RD_M_DrawTextSmallENG(show_endoom ? "on" : "off", 179 + wide_delta, 125, CR_NONE);
 
         //
         // Footer
@@ -2016,22 +2020,25 @@ static void M_RD_Draw_Rendering_2 (void)
         // Поверх других окон
         RD_M_DrawTextSmallRUS(window_ontop ? "drk" : "dsrk", 182 + wide_delta, 65, CR_NONE);
 
+        // Пропорции окна
+        RD_M_DrawTextSmallRUS(aspect_ratio_correct  ? "abrcbhjdfyyst" : "cdj,jlyst", 152 + wide_delta, 75, CR_NONE);
+
         // Отображать значок дискеты
         RD_M_DrawTextSmallRUS(show_diskicon == 1 ? "cybpe" :
                               show_diskicon == 2 ? "cdth[e" :
-                              "dsrk", 241 + wide_delta, 85, CR_NONE);
+                              "dsrk", 241 + wide_delta, 95, CR_NONE);
 
         // Эффект смены экранов
         RD_M_DrawTextSmallRUS(screen_wiping == 1 ? "cnfylfhnysq" :
                               screen_wiping == 2 ? "pfuheprf" :
-                              "dsrk", 202 + wide_delta, 95, CR_NONE);
+                              "dsrk", 202 + wide_delta, 105, CR_NONE);
 
         // Формат скриншотов
-        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 180 + wide_delta, 105, CR_NONE);
+        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 180 + wide_delta, 115, CR_NONE);
 
         // Показывать экран ENDOOM
-        RD_M_DrawTextSmallENG("ENDOOM:", 165 + wide_delta, 115, CR_NONE);
-        RD_M_DrawTextSmallRUS(show_endoom ? "drk" : "dsrk", 222 + wide_delta, 115, CR_NONE);
+        RD_M_DrawTextSmallENG("ENDOOM:", 165 + wide_delta, 125, CR_NONE);
+        RD_M_DrawTextSmallRUS(show_endoom ? "drk" : "dsrk", 222 + wide_delta, 125, CR_NONE);
 
         //
         // Footer
@@ -2208,6 +2215,13 @@ static void M_RD_Change_AlwaysOnTop()
     window_ontop ^= 1;
 
     I_KeepWindowOnTop();
+}
+
+static void M_RD_Change_WindowAspectRatio()
+{
+    aspect_ratio_correct ^= 1;
+    
+    I_ReInitGraphics(REINIT_RENDERER | REINIT_TEXTURES | REINIT_ASPECTRATIO);
 }
 
 static void M_RD_Change_DiskIcon(Direction_t direction)

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -140,6 +140,7 @@ static void M_RD_Change_Smoothing();
 static void M_RD_Change_PorchFlashing();
 
 static void M_RD_Change_WindowBorder();
+static void M_RD_Change_WindowSize(Direction_t direction);
 static void M_RD_Change_WindowTitle();
 static void M_RD_Change_DiskIcon(Direction_t direction);
 static void M_RD_Change_Wiping(Direction_t direction);
@@ -721,13 +722,13 @@ static Menu_t Rendering1Menu = {
 static MenuItem_t Rendering2Items[] = {
     {ITT_TITLE,  "Window options",            "Yfcnhjqrb jryf",                  NULL,                      0}, // Настройки окна
     {ITT_SWITCH, "Bordered window:",          "jryj c hfvrjq:",             M_RD_Change_WindowBorder,   0}, // 
-    {ITT_SWITCH, "Window title:",             "pfujkjdjr jryf:",            M_RD_Change_WindowTitle,    0}, // Заголовок окна
+    {ITT_LRFUNC, "Window size:",              "hfpvth jryf:",      			M_RD_Change_WindowSize,      0}, // Размер окна
+	{ITT_SWITCH, "Window title:",             "pfujkjdjr jryf:",            M_RD_Change_WindowTitle,    0}, // Заголовок окна
     {ITT_TITLE,  "Extra",                     "ljgjkybntkmyj",                   NULL,                      0}, // Дополнительно
 	{ITT_LRFUNC, "Show disk icon:",           "Jnj,hf;fnm pyfxjr lbcrtns:",      M_RD_Change_DiskIcon,      0},
     {ITT_LRFUNC, "Screen wiping effect:",     "\'aatrn cvtys \'rhfyjd:",         M_RD_Change_Wiping,        0},
     {ITT_SWITCH, "Screenshot format:",        "Ajhvfn crhbyijnjd:",              M_RD_Change_Screenshots,   0},
     {ITT_SWITCH, "Show ENDOOM screen:",       "Gjrfpsdfnm \'rhfy",               M_RD_Change_ENDOOM,        0},
-    {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
     {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
 	{ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
     {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
@@ -1924,31 +1925,41 @@ static void M_RD_Draw_Rendering_1 (void)
 
 static void M_RD_Draw_Rendering_2 (void)
 {
-    //static char num[4];
-    
+    char win_width[8];
+    char win_height[8];
+    char *window_size;
+
+    // Consolidate window size string for printing.
+    M_snprintf(win_width, 8, "%d", window_width);
+    M_snprintf(win_height, 8, "%d", window_height);
+    window_size = M_StringJoin(win_width, "x", win_height, NULL);
+
     if (english_language)
     {
         // Bordered window
         RD_M_DrawTextSmallENG(window_border ? "on" : "off", 157 + wide_delta, 35, CR_NONE);
 
+        // Window size
+        RD_M_DrawTextSmallENG(window_size, 119 + wide_delta, 45, CR_NONE);
+
         // Window title
-        RD_M_DrawTextSmallENG(window_title_short ? "brief" : "full", 129 + wide_delta, 45, CR_NONE);
+        RD_M_DrawTextSmallENG(window_title_short ? "brief" : "full", 129 + wide_delta, 55, CR_NONE);
 
         // Show disk icon
         RD_M_DrawTextSmallENG(show_diskicon == 1 ? "bottom" :
                               show_diskicon == 2 ? "top" :
-                              "off", 138 + wide_delta, 65, CR_NONE);
+                              "off", 138 + wide_delta, 75, CR_NONE);
 
         // Screen wiping effect
         RD_M_DrawTextSmallENG(screen_wiping == 1 ? "standard" :
                               screen_wiping == 2 ? "loading" :
-                              "off", 187 + wide_delta, 75, CR_NONE);
+                              "off", 187 + wide_delta, 85, CR_NONE);
 
         // Screenshot format
-        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 174 + wide_delta, 85, CR_NONE);
+        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 174 + wide_delta, 95, CR_NONE);
 
         // Show ENDOOM screen
-        RD_M_DrawTextSmallENG(show_endoom ? "on" : "off", 179 + wide_delta, 95, CR_NONE);
+        RD_M_DrawTextSmallENG(show_endoom ? "on" : "off", 179 + wide_delta, 105, CR_NONE);
 
         //
         // Footer
@@ -1960,25 +1971,28 @@ static void M_RD_Draw_Rendering_2 (void)
         // Окно с рамкой
         RD_M_DrawTextSmallRUS(window_border ? "drk" : "dsrk", 140 + wide_delta, 35, CR_NONE);
 
+        // Размер окна
+        RD_M_DrawTextSmallENG(window_size, 128 + wide_delta, 45, CR_NONE);
+
         // Заголовок окна
-        RD_M_DrawTextSmallRUS(window_title_short ? "rhfnrbq" : "gjlhj,ysq", 151 + wide_delta, 45, CR_NONE);
+        RD_M_DrawTextSmallRUS(window_title_short ? "rhfnrbq" : "gjlhj,ysq", 151 + wide_delta, 55, CR_NONE);
 
         // Отображать значок дискеты
         RD_M_DrawTextSmallRUS(show_diskicon == 1 ? "cybpe" :
                               show_diskicon == 2 ? "cdth[e" :
-                              "dsrk", 241 + wide_delta, 65, CR_NONE);
+                              "dsrk", 241 + wide_delta, 75, CR_NONE);
 
         // Эффект смены экранов
         RD_M_DrawTextSmallRUS(screen_wiping == 1 ? "cnfylfhnysq" :
                               screen_wiping == 2 ? "pfuheprf" :
-                              "dsrk", 202 + wide_delta, 75, CR_NONE);
+                              "dsrk", 202 + wide_delta, 85, CR_NONE);
 
         // Формат скриншотов
-        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 180 + wide_delta, 85, CR_NONE);
+        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 180 + wide_delta, 95, CR_NONE);
 
         // Показывать экран ENDOOM
-        RD_M_DrawTextSmallENG("ENDOOM:", 165 + wide_delta, 95, CR_NONE);
-        RD_M_DrawTextSmallRUS(show_endoom ? "drk" : "dsrk", 222 + wide_delta, 95, CR_NONE);
+        RD_M_DrawTextSmallENG("ENDOOM:", 165 + wide_delta, 105, CR_NONE);
+        RD_M_DrawTextSmallRUS(show_endoom ? "drk" : "dsrk", 222 + wide_delta, 105, CR_NONE);
 
         //
         // Footer
@@ -2098,6 +2112,59 @@ static void M_RD_Change_WindowBorder()
     window_border ^= 1;
     
     I_ToggleWindowBorder();
+}
+
+static void M_RD_Change_WindowSize(Direction_t direction)
+{
+	extern SDL_Window *screen;
+	extern void AdjustWindowSize(void);
+
+    switch (direction)
+    {
+        case LEFT_DIR:
+            window_width  -= BK_isKeyPressed(bk_speed) ? 10 : 1;
+			window_height -= BK_isKeyPressed(bk_speed) ? 10 : 1;
+			// [JN] Sensible?
+			/*
+            if (window_width >= 320 || window_height >= 240)
+            {
+                S_StartSound (NULL, sfx_stnmov);
+            }
+			*/
+        break;
+        case RIGHT_DIR:
+            window_width  += BK_isKeyPressed(bk_speed) ? 10 : 1;
+			window_height += BK_isKeyPressed(bk_speed) ? 10 : 1;
+			// [JN] Sensible?
+			/*
+            if (window_width <= 3440 || window_height <= 1440)
+            {
+                S_StartSound (NULL, sfx_stnmov);
+            }
+			*/
+        break;
+    }
+
+    // Prevent overflows / incorrect values.
+    if (window_width < 320)
+    {
+        window_width = 320;
+    }
+    if (window_width > 3440)
+    {
+        window_width = 3440;
+    }
+    if (window_height < 240)
+    {
+        window_height = 240;
+    }
+    if (window_height > 1440)
+    {
+        window_height = 1440;
+    }
+
+	AdjustWindowSize();
+	SDL_SetWindowSize(screen, window_width, window_height);
 }
 
 static void M_RD_Change_WindowTitle()

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -140,6 +140,7 @@ static void M_RD_Change_Smoothing();
 static void M_RD_Change_PorchFlashing();
 
 static void M_RD_Change_WindowBorder();
+static void M_RD_Change_WindowTitle();
 static void M_RD_Change_DiskIcon(Direction_t direction);
 static void M_RD_Change_Wiping(Direction_t direction);
 static void M_RD_Change_Screenshots();
@@ -719,16 +720,16 @@ static Menu_t Rendering1Menu = {
 
 static MenuItem_t Rendering2Items[] = {
     {ITT_TITLE,  "Window options",            "Yfcnhjqrb jryf",                  NULL,                      0}, // Настройки окна
-    {ITT_SWITCH, "Bordered window:",          "jryj c hfvrjq: d",             M_RD_Change_WindowBorder,   0},
+    {ITT_SWITCH, "Bordered window:",          "jryj c hfvrjq:",             M_RD_Change_WindowBorder,   0}, // 
+    {ITT_SWITCH, "Window title:",             "pfujkjdjr jryf:",            M_RD_Change_WindowTitle,    0}, // Заголовок окна
     {ITT_TITLE,  "Extra",                     "ljgjkybntkmyj",                   NULL,                      0}, // Дополнительно
-    {ITT_LRFUNC, "Show disk icon:",           "Jnj,hf;fnm pyfxjr lbcrtns:",      M_RD_Change_DiskIcon,      0},
+	{ITT_LRFUNC, "Show disk icon:",           "Jnj,hf;fnm pyfxjr lbcrtns:",      M_RD_Change_DiskIcon,      0},
     {ITT_LRFUNC, "Screen wiping effect:",     "\'aatrn cvtys \'rhfyjd:",         M_RD_Change_Wiping,        0},
     {ITT_SWITCH, "Screenshot format:",        "Ajhvfn crhbyijnjd:",              M_RD_Change_Screenshots,   0},
     {ITT_SWITCH, "Show ENDOOM screen:",       "Gjrfpsdfnm \'rhfy",               M_RD_Change_ENDOOM,        0},
     {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
     {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
-    {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
-    {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
+	{ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
     {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
     {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
     {ITT_SETMENU, NULL, /* < Prev Page > */    NULL,                             &Rendering1Menu,           0}  // < Назад
@@ -1930,21 +1931,24 @@ static void M_RD_Draw_Rendering_2 (void)
         // Bordered window
         RD_M_DrawTextSmallENG(window_border ? "on" : "off", 157 + wide_delta, 35, CR_NONE);
 
+        // Window title
+        RD_M_DrawTextSmallENG(window_title_short ? "brief" : "full", 129 + wide_delta, 45, CR_NONE);
+
         // Show disk icon
         RD_M_DrawTextSmallENG(show_diskicon == 1 ? "bottom" :
                               show_diskicon == 2 ? "top" :
-                              "off", 138 + wide_delta, 55, CR_NONE);
+                              "off", 138 + wide_delta, 65, CR_NONE);
 
         // Screen wiping effect
         RD_M_DrawTextSmallENG(screen_wiping == 1 ? "standard" :
                               screen_wiping == 2 ? "loading" :
-                              "off", 187 + wide_delta, 65, CR_NONE);
+                              "off", 187 + wide_delta, 75, CR_NONE);
 
         // Screenshot format
-        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 174 + wide_delta, 75, CR_NONE);
+        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 174 + wide_delta, 85, CR_NONE);
 
         // Show ENDOOM screen
-        RD_M_DrawTextSmallENG(show_endoom ? "on" : "off", 179 + wide_delta, 85, CR_NONE);
+        RD_M_DrawTextSmallENG(show_endoom ? "on" : "off", 179 + wide_delta, 95, CR_NONE);
 
         //
         // Footer
@@ -1956,22 +1960,25 @@ static void M_RD_Draw_Rendering_2 (void)
         // Окно с рамкой
         RD_M_DrawTextSmallRUS(window_border ? "drk" : "dsrk", 140 + wide_delta, 35, CR_NONE);
 
+        // Заголовок окна
+        RD_M_DrawTextSmallRUS(window_title_short ? "rhfnrbq" : "gjlhj,ysq", 151 + wide_delta, 45, CR_NONE);
+
         // Отображать значок дискеты
         RD_M_DrawTextSmallRUS(show_diskicon == 1 ? "cybpe" :
                               show_diskicon == 2 ? "cdth[e" :
-                              "dsrk", 241 + wide_delta, 55, CR_NONE);
+                              "dsrk", 241 + wide_delta, 65, CR_NONE);
 
         // Эффект смены экранов
         RD_M_DrawTextSmallRUS(screen_wiping == 1 ? "cnfylfhnysq" :
                               screen_wiping == 2 ? "pfuheprf" :
-                              "dsrk", 202 + wide_delta, 65, CR_NONE);
+                              "dsrk", 202 + wide_delta, 75, CR_NONE);
 
         // Формат скриншотов
-        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 180 + wide_delta, 75, CR_NONE);
+        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 180 + wide_delta, 85, CR_NONE);
 
         // Показывать экран ENDOOM
-        RD_M_DrawTextSmallENG("ENDOOM:", 165 + wide_delta, 85, CR_NONE);
-        RD_M_DrawTextSmallRUS(show_endoom ? "drk" : "dsrk", 222 + wide_delta, 85, CR_NONE);
+        RD_M_DrawTextSmallENG("ENDOOM:", 165 + wide_delta, 95, CR_NONE);
+        RD_M_DrawTextSmallRUS(show_endoom ? "drk" : "dsrk", 222 + wide_delta, 95, CR_NONE);
 
         //
         // Footer
@@ -2091,6 +2098,13 @@ static void M_RD_Change_WindowBorder()
     window_border ^= 1;
     
     I_ToggleWindowBorder();
+}
+
+static void M_RD_Change_WindowTitle()
+{
+    window_title_short ^= 1;
+    
+    I_InitWindowTitle();
 }
 
 static void M_RD_Change_DiskIcon(Direction_t direction)

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <SDL_scancode.h>
-#include <SDL_video.h>
 
 #include "rd_io.h"
 #include "doomdef.h"
@@ -132,6 +131,8 @@ static void M_StartMessage(char *string,void *routine,boolean input);
 // Rendering
 static void M_RD_Draw_Rendering_1();
 static void M_RD_Draw_Rendering_2();
+
+// Page 1
 static void M_RD_Change_Widescreen(Direction_t direction);
 static void M_RD_Change_Renderer();
 static void M_RD_Change_VSync();
@@ -140,6 +141,7 @@ static void M_RD_Change_PerfCounter();
 static void M_RD_Change_Smoothing();
 static void M_RD_Change_PorchFlashing();
 
+// Page 2
 static void M_RD_Change_WindowBorder();
 static void M_RD_Change_WindowSize(Direction_t direction);
 static void M_RD_Change_WindowTitle();
@@ -722,20 +724,20 @@ static Menu_t Rendering1Menu = {
 };
 
 static MenuItem_t Rendering2Items[] = {
-    {ITT_TITLE,  "Window options",            "Yfcnhjqrb jryf",                  NULL,                      0}, // Настройки окна
-    {ITT_SWITCH, "Bordered window:",          "jryj c hfvrjq:",             M_RD_Change_WindowBorder,   0}, // 
-    {ITT_LRFUNC, "Window size:",              "hfpvth jryf:",      			M_RD_Change_WindowSize,      0}, // Размер окна
-	{ITT_SWITCH, "Window title:",             "pfujkjdjr jryf:",            M_RD_Change_WindowTitle,    0}, // Заголовок окна
-	{ITT_SWITCH, "Always on top:",            "gjdth[ lheub[ jrjy:",        M_RD_Change_AlwaysOnTop,    0}, // Поверх других окон
-    {ITT_TITLE,  "Extra",                     "ljgjkybntkmyj",                   NULL,                      0}, // Дополнительно
-	{ITT_LRFUNC, "Show disk icon:",           "Jnj,hf;fnm pyfxjr lbcrtns:",      M_RD_Change_DiskIcon,      0},
-    {ITT_LRFUNC, "Screen wiping effect:",     "\'aatrn cvtys \'rhfyjd:",         M_RD_Change_Wiping,        0},
-    {ITT_SWITCH, "Screenshot format:",        "Ajhvfn crhbyijnjd:",              M_RD_Change_Screenshots,   0},
-    {ITT_SWITCH, "Show ENDOOM screen:",       "Gjrfpsdfnm \'rhfy",               M_RD_Change_ENDOOM,        0},
-    {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
-    {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
-    {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
-    {ITT_SETMENU, NULL, /* < Prev Page > */    NULL,                             &Rendering1Menu,           0}  // < Назад
+    {ITT_TITLE,   "Window options",         "Yfcnhjqrb jryf",             NULL,                     0}, // Настройки окна
+    {ITT_SWITCH,  "Bordered window:",       "jryj c hfvrjq:",             M_RD_Change_WindowBorder, 0}, // Окно с рамкой
+    {ITT_LRFUNC,  "Window size:",           "hfpvth jryf:",               M_RD_Change_WindowSize,   0}, // Размер окна
+    {ITT_SWITCH,  "Window title:",          "pfujkjdjr jryf:",            M_RD_Change_WindowTitle,  0}, // Заголовок окна
+    {ITT_SWITCH,  "Always on top:",         "gjdth[ lheub[ jrjy:",        M_RD_Change_AlwaysOnTop,  0}, // Поверх других окон
+    {ITT_TITLE,   "Extra",                  "ljgjkybntkmyj",              NULL,                     0}, // Дополнительно
+    {ITT_LRFUNC,  "Show disk icon:",        "Jnj,hf;fnm pyfxjr lbcrtns:", M_RD_Change_DiskIcon,     0}, // Отображать значок дискеты
+    {ITT_LRFUNC,  "Screen wiping effect:",  "\'aatrn cvtys \'rhfyjd:",    M_RD_Change_Wiping,       0}, // Эффект смены экранов
+    {ITT_SWITCH,  "Screenshot format:",     "Ajhvfn crhbyijnjd:",         M_RD_Change_Screenshots,  0}, // Формат скриншотов
+    {ITT_SWITCH,  "Show ENDOOM screen:",    "Gjrfpsdfnm \'rhfy",          M_RD_Change_ENDOOM,       0}, // Показывать экран ENDOOM
+    {ITT_EMPTY,   NULL,                     NULL,                         NULL,                     0},
+    {ITT_EMPTY,   NULL,                     NULL,                         NULL,                     0},
+    {ITT_EMPTY,   NULL,                     NULL,                         NULL,                     0},
+    {ITT_SETMENU, NULL, /* < Prev Page > */ NULL,                         &Rendering1Menu,          0}  // < Назад
 };
 
 static Menu_t Rendering2Menu = {
@@ -1775,10 +1777,9 @@ static void M_RD_Draw_Rendering_1 (void)
         }
 
         // Informative messages
-        if ((aspect_ratio_temp != aspect_ratio || opengles_renderer_temp != opengles_renderer)
-        && CurrentItPos != 4)
+        if (aspect_ratio_temp != aspect_ratio || opengles_renderer_temp != opengles_renderer)
         {
-            RD_M_DrawTextSmallCenteredENG("PROGRAM MUST BE RESTARTED", 155, CR_WHITE);
+            RD_M_DrawTextSmallCenteredENG("PROGRAM MUST BE RESTARTED", 135, MenuTime & 32 ? CR_WHITE : CR_GRAY);
         }
 
         // Vertical synchronization
@@ -1822,7 +1823,7 @@ static void M_RD_Draw_Rendering_1 (void)
         // Tip for faster sliding
         if (CurrentItPos == 4)
         {
-            RD_M_DrawTextSmallCenteredENG("HOLD RUN BUTTON FOR FASTER SLIDING", 155, CR_DARKRED);
+            RD_M_DrawTextSmallCenteredENG("HOLD RUN BUTTON FOR FASTER SLIDING", 145, CR_GRAY);
         }
 
         //
@@ -1863,10 +1864,9 @@ static void M_RD_Draw_Rendering_1 (void)
         }
 
         // Informative message: Необходим перезапуск программы
-        if ((aspect_ratio_temp != aspect_ratio || opengles_renderer_temp != opengles_renderer)
-        && CurrentItPos != 4)
+        if (aspect_ratio_temp != aspect_ratio || opengles_renderer_temp != opengles_renderer)
         {
-            RD_M_DrawTextSmallCenteredRUS("ytj,[jlbv gthtpfgecr ghjuhfvvs", 155, CR_WHITE);
+            RD_M_DrawTextSmallCenteredRUS("ytj,[jlbv gthtpfgecr ghjuhfvvs", 125, MenuTime & 32 ? CR_WHITE : CR_GRAY);
         }
 
         // Вертикальная синхронизация
@@ -1914,8 +1914,8 @@ static void M_RD_Draw_Rendering_1 (void)
         // удерживайте кнопку бега
         if (CurrentItPos == 4)
         {
-            RD_M_DrawTextSmallCenteredRUS("LKZ ECRJHTYYJUJ GHJKBCNSDFYBZ", 155, CR_DARKRED);
-            RD_M_DrawTextSmallCenteredRUS("ELTH;BDFQNT RYJGRE ,TUF", 164, CR_DARKRED);
+            RD_M_DrawTextSmallCenteredRUS("LKZ ECRJHTYYJUJ GHJKBCNSDFYBZ", 135, CR_GRAY);
+            RD_M_DrawTextSmallCenteredRUS("ELTH;BDFQNT RYJGRE ,TUF", 145, CR_GRAY);
         }
 
         //
@@ -1927,8 +1927,8 @@ static void M_RD_Draw_Rendering_1 (void)
 
 static void M_RD_Draw_Rendering_2 (void)
 {
-    char win_width[8];
-    char win_height[8];
+    char  win_width[8];
+    char  win_height[8];
     char *window_size;
 
     // Consolidate window size string for printing.
@@ -1942,13 +1942,28 @@ static void M_RD_Draw_Rendering_2 (void)
         RD_M_DrawTextSmallENG(window_border ? "on" : "off", 157 + wide_delta, 35, CR_NONE);
 
         // Window size
-        RD_M_DrawTextSmallENG(window_size, 119 + wide_delta, 45, CR_NONE);
+        RD_M_DrawTextSmallENG(window_size, 119 + wide_delta, 45, fullscreen ? CR_DARKRED : CR_NONE);
+
+        // Tip for faster sliding
+        if (CurrentItPos == 2)
+        {
+            if (fullscreen)
+            {
+                RD_M_DrawTextSmallCenteredENG("SWITCH TO WINDOWED MODE FIRST", 135, CR_GRAY);
+                RD_M_DrawTextSmallCenteredENG("BY PRESSING \"ALT+ENTER\"", 145, CR_GRAY);
+            }
+            else
+            {
+                RD_M_DrawTextSmallCenteredENG("USE ARROW KEYS TO CHANGE SIZE,", 135, CR_GRAY);
+                RD_M_DrawTextSmallCenteredENG("HOLD RUN BUTTON FOR FASTER SLIDING.", 145, CR_GRAY);
+            }
+        }
 
         // Window title
         RD_M_DrawTextSmallENG(window_title_short ? "brief" : "full", 129 + wide_delta, 55, CR_NONE);
 
-		// Always on top
-		RD_M_DrawTextSmallENG(window_ontop ? "on" : "off", 139 + wide_delta, 65, CR_NONE);
+        // Always on top
+        RD_M_DrawTextSmallENG(window_ontop ? "on" : "off", 139 + wide_delta, 65, CR_NONE);
 
         // Show disk icon
         RD_M_DrawTextSmallENG(show_diskicon == 1 ? "bottom" :
@@ -1977,13 +1992,29 @@ static void M_RD_Draw_Rendering_2 (void)
         RD_M_DrawTextSmallRUS(window_border ? "drk" : "dsrk", 140 + wide_delta, 35, CR_NONE);
 
         // Размер окна
-        RD_M_DrawTextSmallENG(window_size, 128 + wide_delta, 45, CR_NONE);
+        RD_M_DrawTextSmallENG(window_size, 128 + wide_delta, 45, fullscreen ? CR_DARKRED : CR_NONE);
+
+        // Подсказка для ускоренного изменения размера
+        if (CurrentItPos == 2)
+        {
+            if (fullscreen)
+            {
+                RD_M_DrawTextSmallCenteredRUS("GTHTRK.XBNTCM D JRJYYSQ HT;BV", 135, CR_GRAY);
+                RD_M_DrawTextSmallRUS("BCGJKMPEZ CJXTNFYBT RKFDBI", 16, 145, CR_GRAY);
+                RD_M_DrawTextSmallENG("\"ALT+ENTER\"", 220 + wide_delta, 145, CR_GRAY);
+            }
+            else
+            {
+            RD_M_DrawTextSmallCenteredRUS("LKZ ECRJHTYYJUJ BPVTYTYBZ HFPVTHF", 135, CR_GRAY);
+            RD_M_DrawTextSmallCenteredRUS("ELTH;BDFQNT RYJGRE ,TUF", 145, CR_GRAY);
+            }
+        }
 
         // Заголовок окна
         RD_M_DrawTextSmallRUS(window_title_short ? "rhfnrbq" : "gjlhj,ysq", 151 + wide_delta, 55, CR_NONE);
 
-		// Поверх других окон
-		RD_M_DrawTextSmallRUS(window_ontop ? "drk" : "dsrk", 182 + wide_delta, 65, CR_NONE);
+        // Поверх других окон
+        RD_M_DrawTextSmallRUS(window_ontop ? "drk" : "dsrk", 182 + wide_delta, 65, CR_NONE);
 
         // Отображать значок дискеты
         RD_M_DrawTextSmallRUS(show_diskicon == 1 ? "cybpe" :
@@ -2122,34 +2153,24 @@ static void M_RD_Change_WindowBorder()
     I_ToggleWindowBorder();
 }
 
-extern SDL_Window *screen;
+
 static void M_RD_Change_WindowSize(Direction_t direction)
 {
-	extern void AdjustWindowSize(void);
+    // Disallow to change size in full screen mode.
+    if (fullscreen)
+    {
+        return;
+    }
 
     switch (direction)
     {
         case LEFT_DIR:
             window_width  -= BK_isKeyPressed(bk_speed) ? 10 : 1;
-			window_height -= BK_isKeyPressed(bk_speed) ? 10 : 1;
-			// [JN] Sensible?
-			/*
-            if (window_width >= 320 || window_height >= 240)
-            {
-                S_StartSound (NULL, sfx_stnmov);
-            }
-			*/
+            window_height -= BK_isKeyPressed(bk_speed) ? 10 : 1;
         break;
         case RIGHT_DIR:
             window_width  += BK_isKeyPressed(bk_speed) ? 10 : 1;
-			window_height += BK_isKeyPressed(bk_speed) ? 10 : 1;
-			// [JN] Sensible?
-			/*
-            if (window_width <= 3440 || window_height <= 1440)
-            {
-                S_StartSound (NULL, sfx_stnmov);
-            }
-			*/
+            window_height += BK_isKeyPressed(bk_speed) ? 10 : 1;
         break;
     }
 
@@ -2171,8 +2192,8 @@ static void M_RD_Change_WindowSize(Direction_t direction)
         window_height = 1440;
     }
 
-	AdjustWindowSize();
-	SDL_SetWindowSize(screen, window_width, window_height);
+    AdjustWindowSize();
+    SDL_SetWindowSize(screen, window_width, window_height);
 }
 
 static void M_RD_Change_WindowTitle()

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -142,6 +142,7 @@ static void M_RD_Change_PorchFlashing();
 static void M_RD_Change_WindowBorder();
 static void M_RD_Change_WindowSize(Direction_t direction);
 static void M_RD_Change_WindowTitle();
+static void M_RD_Change_AlwaysOnTop();
 static void M_RD_Change_DiskIcon(Direction_t direction);
 static void M_RD_Change_Wiping(Direction_t direction);
 static void M_RD_Change_Screenshots();
@@ -724,13 +725,13 @@ static MenuItem_t Rendering2Items[] = {
     {ITT_SWITCH, "Bordered window:",          "jryj c hfvrjq:",             M_RD_Change_WindowBorder,   0}, // 
     {ITT_LRFUNC, "Window size:",              "hfpvth jryf:",      			M_RD_Change_WindowSize,      0}, // Размер окна
 	{ITT_SWITCH, "Window title:",             "pfujkjdjr jryf:",            M_RD_Change_WindowTitle,    0}, // Заголовок окна
+	{ITT_SWITCH, "Always on top:",            "gjdth[ lheub[ jrjy:",        M_RD_Change_AlwaysOnTop,    0}, // Поверх других окон
     {ITT_TITLE,  "Extra",                     "ljgjkybntkmyj",                   NULL,                      0}, // Дополнительно
 	{ITT_LRFUNC, "Show disk icon:",           "Jnj,hf;fnm pyfxjr lbcrtns:",      M_RD_Change_DiskIcon,      0},
     {ITT_LRFUNC, "Screen wiping effect:",     "\'aatrn cvtys \'rhfyjd:",         M_RD_Change_Wiping,        0},
     {ITT_SWITCH, "Screenshot format:",        "Ajhvfn crhbyijnjd:",              M_RD_Change_Screenshots,   0},
     {ITT_SWITCH, "Show ENDOOM screen:",       "Gjrfpsdfnm \'rhfy",               M_RD_Change_ENDOOM,        0},
     {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
-	{ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
     {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
     {ITT_EMPTY,   NULL,                        NULL,                             NULL,                      0},
     {ITT_SETMENU, NULL, /* < Prev Page > */    NULL,                             &Rendering1Menu,           0}  // < Назад
@@ -1945,21 +1946,24 @@ static void M_RD_Draw_Rendering_2 (void)
         // Window title
         RD_M_DrawTextSmallENG(window_title_short ? "brief" : "full", 129 + wide_delta, 55, CR_NONE);
 
+		// Always on top
+		RD_M_DrawTextSmallENG(window_ontop ? "on" : "off", 139 + wide_delta, 65, CR_NONE);
+
         // Show disk icon
         RD_M_DrawTextSmallENG(show_diskicon == 1 ? "bottom" :
                               show_diskicon == 2 ? "top" :
-                              "off", 138 + wide_delta, 75, CR_NONE);
+                              "off", 138 + wide_delta, 85, CR_NONE);
 
         // Screen wiping effect
         RD_M_DrawTextSmallENG(screen_wiping == 1 ? "standard" :
                               screen_wiping == 2 ? "loading" :
-                              "off", 187 + wide_delta, 85, CR_NONE);
+                              "off", 187 + wide_delta, 95, CR_NONE);
 
         // Screenshot format
-        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 174 + wide_delta, 95, CR_NONE);
+        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 174 + wide_delta, 105, CR_NONE);
 
         // Show ENDOOM screen
-        RD_M_DrawTextSmallENG(show_endoom ? "on" : "off", 179 + wide_delta, 105, CR_NONE);
+        RD_M_DrawTextSmallENG(show_endoom ? "on" : "off", 179 + wide_delta, 115, CR_NONE);
 
         //
         // Footer
@@ -1977,22 +1981,25 @@ static void M_RD_Draw_Rendering_2 (void)
         // Заголовок окна
         RD_M_DrawTextSmallRUS(window_title_short ? "rhfnrbq" : "gjlhj,ysq", 151 + wide_delta, 55, CR_NONE);
 
+		// Поверх других окон
+		RD_M_DrawTextSmallRUS(window_ontop ? "drk" : "dsrk", 182 + wide_delta, 65, CR_NONE);
+
         // Отображать значок дискеты
         RD_M_DrawTextSmallRUS(show_diskicon == 1 ? "cybpe" :
                               show_diskicon == 2 ? "cdth[e" :
-                              "dsrk", 241 + wide_delta, 75, CR_NONE);
+                              "dsrk", 241 + wide_delta, 85, CR_NONE);
 
         // Эффект смены экранов
         RD_M_DrawTextSmallRUS(screen_wiping == 1 ? "cnfylfhnysq" :
                               screen_wiping == 2 ? "pfuheprf" :
-                              "dsrk", 202 + wide_delta, 85, CR_NONE);
+                              "dsrk", 202 + wide_delta, 95, CR_NONE);
 
         // Формат скриншотов
-        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 180 + wide_delta, 95, CR_NONE);
+        RD_M_DrawTextSmallENG(png_screenshots ? "png" : "pcx", 180 + wide_delta, 105, CR_NONE);
 
         // Показывать экран ENDOOM
-        RD_M_DrawTextSmallENG("ENDOOM:", 165 + wide_delta, 105, CR_NONE);
-        RD_M_DrawTextSmallRUS(show_endoom ? "drk" : "dsrk", 222 + wide_delta, 105, CR_NONE);
+        RD_M_DrawTextSmallENG("ENDOOM:", 165 + wide_delta, 115, CR_NONE);
+        RD_M_DrawTextSmallRUS(show_endoom ? "drk" : "dsrk", 222 + wide_delta, 115, CR_NONE);
 
         //
         // Footer
@@ -2114,9 +2121,9 @@ static void M_RD_Change_WindowBorder()
     I_ToggleWindowBorder();
 }
 
+extern SDL_Window *screen;
 static void M_RD_Change_WindowSize(Direction_t direction)
 {
-	extern SDL_Window *screen;
 	extern void AdjustWindowSize(void);
 
     switch (direction)
@@ -2172,6 +2179,13 @@ static void M_RD_Change_WindowTitle()
     window_title_short ^= 1;
     
     I_InitWindowTitle();
+}
+
+static void M_RD_Change_AlwaysOnTop()
+{
+    window_ontop ^= 1;
+
+    SDL_SetWindowAlwaysOnTop(screen, window_ontop ? SDL_TRUE : SDL_FALSE);
 }
 
 static void M_RD_Change_DiskIcon(Direction_t direction)

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -2207,7 +2207,7 @@ static void M_RD_Change_AlwaysOnTop()
 {
     window_ontop ^= 1;
 
-    SDL_SetWindowAlwaysOnTop(screen, window_ontop ? SDL_TRUE : SDL_FALSE);
+    I_KeepWindowOnTop();
 }
 
 static void M_RD_Change_DiskIcon(Direction_t direction)

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <SDL_scancode.h>
+#include <SDL_video.h>
 
 #include "rd_io.h"
 #include "doomdef.h"

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -709,8 +709,6 @@ extern int mouseSensitivity;
 
 extern boolean precache;        // if true, load all graphics at level load
 
-extern byte *screen;            // off screen work buffer, from V_video.c
-
 extern boolean singledemo;      // quit after playing a demo from cmdline
 
 extern int bodyqueslot;

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -373,7 +373,7 @@ static void SetShowCursor (const boolean show)
 
 // Adjust window_width / window_height variables to be an an aspect
 // ratio consistent with the aspect_ratio_correct variable.
-static void AdjustWindowSize(void)
+void AdjustWindowSize(void)
 {
     if (aspect_ratio_correct)
     {

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -538,8 +538,10 @@ static void I_ToggleFullScreen(void)
 
 void I_ToggleWindowBorder (void)
 {
-    const int x_old = window_position_x;
-    const int y_old = window_position_y;
+    // Prevent window title to appear above screen bounds,
+    // if borded is toggled in full screen mode.
+    const int x_old = window_position_x == 0 ? 64 : window_position_x;
+    const int y_old = window_position_y == 0 ? 64 : window_position_y;
 	
     if (window_border)
     {
@@ -1978,7 +1980,7 @@ void I_BindVideoVariables(void)
     M_BindIntVariable("window_width",              &window_width);
     M_BindIntVariable("window_height",             &window_height);
     M_BindIntVariable("window_border",             &window_border);
-	M_BindIntVariable("window_ontop",              &window_ontop);
+    M_BindIntVariable("window_ontop",              &window_ontop);
     M_BindIntVariable("grabmouse",                 &grabmouse);
     M_BindStringVariable("video_driver",           &video_driver);
     M_BindIntVariable("window_position_x",         &window_position_x);

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -556,6 +556,11 @@ void I_ToggleWindowBorder (void)
     }
 }
 
+void I_KeepWindowOnTop (void)
+{
+    SDL_SetWindowAlwaysOnTop(screen, window_ontop ? SDL_TRUE : SDL_FALSE);
+}
+
 void I_GetEvent(void)
 {
     extern void I_HandleKeyboardEvent(SDL_Event *sdlevent);
@@ -1575,6 +1580,10 @@ static void SetVideoMode(void)
 #ifdef _WIN32
 	DisableWinRound(screen);
 #endif
+
+    // [JN] Should we keep window above other windows?
+
+    I_KeepWindowOnTop();
 
     // Important: Set the "logical size" of the rendering context. At the same
     // time this also defines the aspect ratio that is preserved while scaling

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -114,6 +114,10 @@ int window_position_x = 0;
 
 int window_border = 1;
 
+// [JN] Is window always on top?
+
+int window_ontop = 0;
+
 // SDL display number on which to run.
 
 int video_display = 0;
@@ -1974,6 +1978,7 @@ void I_BindVideoVariables(void)
     M_BindIntVariable("window_width",              &window_width);
     M_BindIntVariable("window_height",             &window_height);
     M_BindIntVariable("window_border",             &window_border);
+	M_BindIntVariable("window_ontop",              &window_ontop);
     M_BindIntVariable("grabmouse",                 &grabmouse);
     M_BindStringVariable("video_driver",           &video_driver);
     M_BindIntVariable("window_position_x",         &window_position_x);

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -55,7 +55,7 @@
 // These are (1) the window (or the full screen) that our game is rendered to
 // and (2) the renderer that scales the texture (see below) into this window.
 
-static SDL_Window *screen;
+SDL_Window *screen;
 static SDL_Renderer *renderer;
 
 // Window title
@@ -529,6 +529,21 @@ static void I_ToggleFullScreen(void)
     {
         AdjustWindowSize();
         SDL_SetWindowSize(screen, window_width, window_height);
+    }
+}
+
+void I_ToggleWindowBorder (void)
+{
+    if (window_border)
+    {
+        SDL_SetWindowBordered(screen, SDL_TRUE);
+        SDL_SetWindowPosition(screen, 64, 64);
+        
+    }
+    else
+    {
+        SDL_SetWindowBordered(screen, SDL_FALSE);
+        SDL_SetWindowPosition(screen, 0, 0);
     }
 }
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -534,10 +534,13 @@ static void I_ToggleFullScreen(void)
 
 void I_ToggleWindowBorder (void)
 {
+    const int x_old = window_position_x;
+    const int y_old = window_position_y;
+	
     if (window_border)
     {
         SDL_SetWindowBordered(screen, SDL_TRUE);
-        SDL_SetWindowPosition(screen, 64, 64);
+        SDL_SetWindowPosition(screen, x_old, y_old);
         
     }
     else

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <SDL.h>
 #include "doomtype.h"
 
 
@@ -116,6 +117,10 @@ void I_StartTic (void);
 // Enable the loading disk image displayed when reading from disk.
 
 void I_EnableLoadingDisk(int xoffs, int yoffs);
+
+void AdjustWindowSize(void);
+
+extern SDL_Window *screen;
 
 extern char *video_driver;
 extern boolean screenvisible;

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -103,6 +103,7 @@ void I_BindVideoVariables(void);
 void I_InitWindowTitle(void);
 void I_InitWindowIcon(void);
 void I_ToggleWindowBorder (void);
+void I_KeepWindowOnTop (void);
 
 // Called before processing any tics in a frame (just after displaying a frame).
 // Time consuming syncronous operations are performed here (joystick reading).

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -101,6 +101,7 @@ void I_BindVideoVariables(void);
 
 void I_InitWindowTitle(void);
 void I_InitWindowIcon(void);
+void I_ToggleWindowBorder (void);
 
 // Called before processing any tics in a frame (just after displaying a frame).
 // Time consuming syncronous operations are performed here (joystick reading).
@@ -135,4 +136,4 @@ extern int vga_porch_flash;
 extern int force_software_renderer;
 
 extern int window_border;
-extern void I_ToggleWindowBorder (void);
+extern int window_title_short;

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -136,4 +136,6 @@ extern int vga_porch_flash;
 extern int force_software_renderer;
 
 extern int window_border;
+extern int window_width;
+extern int window_height;
 extern int window_title_short;

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -133,3 +133,6 @@ extern int aspect_ratio_correct;
 extern int smoothing;
 extern int vga_porch_flash;
 extern int force_software_renderer;
+
+extern int window_border;
+extern void I_ToggleWindowBorder (void);

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -139,3 +139,4 @@ extern int window_border;
 extern int window_width;
 extern int window_height;
 extern int window_title_short;
+extern int window_ontop;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -364,6 +364,12 @@ static default_t defaults_list[] =
     CONFIG_VARIABLE_INT(window_title_short),
 
     //!
+    // [JN] If true, window will be pinned on top of other windows.
+    //
+
+    CONFIG_VARIABLE_INT(window_ontop),
+
+    //!
     // Window width when running in windowed mode.
     //
 


### PR DESCRIPTION
This should reveal some previously hidden options, if it's worth at all. Todo's:

* Window size: left<->right (only in windowed mode, it's not resolution changing).
* Window title: short/long.
* Window always on top? (`SDL_WINDOW_ALWAYS_ON_TOP` requires window recreation) 
* Window opacity?
* aspect_ratio?
* startup_delay?
* resize_delay?