### PR TITLE
Add directory based autoload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ check_symbol_exists(mmap "sys/mman.h" HAVE_MMAP)
 check_symbol_exists(i386_iopl "i386/pio.h" HAVE_LIBI386)
 check_symbol_exists(amd64_iopl "amd64/pio.h" HAVE_LIBAMD64)
 
+check_include_file("dirent.h" HAVE_DIRENT_H)
 check_include_file("dev/isa/spkrio.h" HAVE_DEV_ISA_SPKRIO_H)
 check_include_file("dev/speaker/speaker.h" HAVE_DEV_SPEAKER_SPEAKER_H)
 check_include_file("linux/kd.h" HAVE_LINUX_KD_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ add_compile_options_checked(
     -Wno-unknown-pragmas
     -Wno-unused-result
     -Wno-format-nonliteral
+    -Wno-discarded-qualifiers
+    -Wno-incompatible-pointer-types-discards-qualifiers
 )
 
 if(MSVC)

--- a/man/docgen.py
+++ b/man/docgen.py
@@ -321,8 +321,18 @@ class CLIParam:
         result = "| %s | %s | %s |\n" % (name, text, games)
 
         # html escape
-        result = result.replace("<", "&lt;")
-        result = result.replace(">", "&gt;")
+        result_list = list(result)
+        in_quotas: bool = False
+        index: int = 0
+        while index < result_list.__len__():
+            if result_list[index] == '\'':
+                in_quotas = not in_quotas
+            elif not in_quotas and (result_list[index] == '<' or result_list[index] == '>'):
+                result_list.insert(index, "\\")
+                index += 1
+            index += 1
+
+        result = ''.join(result_list)
         result = result.replace("\\'", "\"")
         result = result.replace("'", "`")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,12 @@ target_link_libraries(Common PUBLIC
     SDL2::SDL2
 )
 
+if(WIN32 AND MSVC)
+    target_sources(Common PRIVATE
+        win_opendir.c       win_opendir.h
+    )
+endif()
+
 # Game Library
 add_library(Game STATIC EXCLUDE_FROM_ALL
     aes_prng.c          aes_prng.h
@@ -53,6 +59,7 @@ add_library(Game STATIC EXCLUDE_FROM_ALL
     i_controller.c      i_controller.h
     i_endoom.c          i_endoom.h
     i_input.c           i_input.h
+    i_glob.c            i_glob.h
                         i_swap.h
     i_pcsound.c
     i_sdlsound.c
@@ -112,6 +119,7 @@ target_compile_definitions(Game PRIVATE
     "$<$<BOOL:${PNG_FOUND}>:HAVE_LIBPNG>"
     "$<$<BOOL:${HAVE_MMAP}>:HAVE_MMAP>"
     "$<$<BOOL:${BUILD_PORTABLE}>:BUILD_PORTABLE>"
+    "$<$<BOOL:${HAVE_DIRENT_H}>:HAVE_DIRENT_H>"
     "$<IF:$<BOOL:${HAVE_DECL_SSCANF_S}>,HAVE_DECL_SSCANF_S=1,HAVE_DECL_SSCANF_S=0>"
     PACKAGE_TARNAME="${PACKAGE_TARNAME}"
     PROGRAM_PREFIX="${PROGRAM_PREFIX}"

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -41,6 +41,7 @@
 #include "i_endoom.h"
 #include "i_controller.h"
 #include "i_input.h"
+#include "i_glob.h"
 #include "i_sound.h"
 #include "i_system.h"
 #include "i_timer.h"
@@ -99,17 +100,12 @@ int english_language = -1;
 int english_language = 1;
 #endif
 
-/*
-================================================================================
-=
-= [JN] PWAD autoloading. Initially all 4 values are empty.
-=
-================================================================================
-*/
+// -----------------------------------------------------------------------------
+// [JN] PWAD autoloading
+// -----------------------------------------------------------------------------
 
-static char *autoloadglobalpwad[10]     = { "", "", "", "" };
-static char *autoloadregisteredpwad[10] = { "", "", "", "" };
-static char *autoloadretailpwad[10]     = { "", "", "", "" };
+char* autoload_root = "";
+char* autoload_dir  = NULL;
 
 //------------------------------------------------------------------------------
 //
@@ -945,20 +941,8 @@ void D_BindVariables(void)
     // [JN] Support for fallback to the English language.
     M_BindIntVariable("english_language",       &english_language);
 
-    // [JN] PWAD autoloading. Note that we are using variables 1..4, not 0...3.
-    for (i = 1 ; i < 5 ; ++i)
-    {
-        static char pwad[32];
-
-        M_snprintf(pwad, sizeof(pwad), "autoload_global_pwad%i", i);
-        M_BindStringVariable(pwad, &autoloadglobalpwad[i]);
-
-        M_snprintf(pwad, sizeof(pwad), "autoload_registered_pwad%i", i);
-        M_BindStringVariable(pwad, &autoloadregisteredpwad[i]);
-
-        M_snprintf(pwad, sizeof(pwad), "autoload_retail_pwad%i", i);
-        M_BindStringVariable(pwad, &autoloadretailpwad[i]);
-    }
+    // [JN] PWAD autoloading
+    M_BindStringVariable("autoload_root", &autoload_root);
 
     // Rendering
     M_BindIntVariable("uncapped_fps",           &uncapped_fps);
@@ -1093,6 +1077,48 @@ static void D_Endoom(void)
     }
 
     I_Endoom(endoom_data);
+}
+
+void AutoloadFiles(const char* wadName);
+
+void LoadFile(char* filePath, boolean autoload)
+{
+    printf(english_language ?
+           " adding: %s\n" :
+           " добавление: %s\n",
+           filePath);
+    W_MergeFile(filePath);
+
+    char* fileName = M_FileName(filePath);
+
+    // * Add special wad support here
+
+    if(autoload && M_StrCaseStr(fileName, ".wad"))
+    {
+        AutoloadFiles(fileName);
+    }
+}
+
+void AutoloadFiles(const char* wadName)
+{
+    char* autoload_subdir = M_StringDuplicate(wadName);
+    M_ForceLowercase(autoload_subdir);
+    char* autoload_path = M_StringJoin(autoload_dir, DIR_SEPARATOR_S, autoload_subdir, NULL);
+    free(autoload_subdir);
+
+    glob_t* glob;
+    char* filename;
+
+    glob = I_StartMultiGlob(autoload_path, GLOB_FLAG_NOCASE|GLOB_FLAG_SORTED, "*.*", NULL);
+    while((filename = I_NextGlob(glob)) != NULL)
+    {
+        printf(english_language ?
+               " [Autoload]" :
+               " [Автозагрузка]");
+        LoadFile(filename, false);
+    }
+    I_EndGlob(glob);
+    free(autoload_path);
 }
 
 //---------------------------------------------------------------------------
@@ -1455,49 +1481,21 @@ void D_DoomMain(void)
     // [JN] PWAD autoloading routine. Scan through all 3 
     // available variables, and don't load an empty ones. 
     // Note: you cannot use autoload with the Shareware, buy a full version!
-    if (gamemode != shareware)
+    int autoloadDir_param = M_CheckParmWithArgs("-autoloadroot", 1);
+    if(autoloadDir_param)
     {
-        int i;
+        autoload_dir = myargv[autoloadDir_param + 1];
+    }
+    else
+    {
+        autoload_dir = autoload_root;
+    }
 
-        for (i = 1 ; i < 5 ; ++i)
-        {
-            // [JN] If autoloads have not been set, initialize with defaults.
-            if (autoloadglobalpwad[i] == NULL)
-                autoloadglobalpwad[i] = "";
-            if (autoloadregisteredpwad[i] == NULL)
-                autoloadregisteredpwad[i] = "";
-            if (autoloadretailpwad[i] == NULL)
-                autoloadretailpwad[i] = "";
-
-            if (strcmp(autoloadglobalpwad[i], ""))
-            {
-                W_MergeFile(autoloadglobalpwad[i]);
-                printf(english_language ? 
-                      " autoloading: %s\n" : " автозагрузка: %s\n",
-                        autoloadglobalpwad[i]);
-            }
-
-            if (gamemode == registered)
-            {
-                if (strcmp(autoloadregisteredpwad[i], ""))
-                {
-                    W_MergeFile(autoloadregisteredpwad[i]);
-                    printf(english_language ?
-                           " autoloading: %s\n" : " автозагрузка: %s\n",
-                           autoloadregisteredpwad[i]);
-                }
-            }
-            else if (gamemode == retail)
-            {
-                if (strcmp(autoloadretailpwad[i], ""))
-                {
-                    W_MergeFile(autoloadretailpwad[i]);
-                    printf(english_language ?
-                           " autoloading: %s\n" : " автозагрузка: %s\n",
-                           autoloadretailpwad[i]);
-                }
-            }
-        }
+    boolean allowAutoload = gamemode != shareware && !M_ParmExists("-noautoload") && strcmp(autoload_dir, "") != 0;
+    if(allowAutoload)
+    {
+        AutoloadFiles("heretic-all");
+        AutoloadFiles(iwadfile);
     }
 
     // [JN] Параметр "-file" перенесен из w_main.c
@@ -1511,11 +1509,7 @@ void D_DoomMain(void)
         {
             char *filename;
             filename = D_TryFindWADByName(myargv[newpwadfile]);
-            printf(english_language ?
-                   " adding: %s\n" :
-                   " добавление: %s\n",
-                   filename);
-            W_MergeFile(filename);
+            LoadFile(filename, allowAutoload);
         }
     }
 

--- a/src/i_glob.c
+++ b/src/i_glob.c
@@ -1,0 +1,370 @@
+//
+// Copyright(C) 2018 Simon Howard
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+//
+// File globbing API. This allows the contents of the filesystem
+// to be interrogated.
+//
+
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "i_glob.h"
+#include "m_misc.h"
+#include "rd_io.h"
+
+#if defined(_MSC_VER)
+// For Visual C++, we need to include the win_opendir module.
+#include "../win32/win_opendir.h"
+#elif defined(HAVE_DIRENT_H)
+#include <dirent.h>
+#elif defined(__WATCOMC__)
+// Watcom has the same API in a different header.
+#include <direct.h>
+#else
+#define NO_DIRENT_IMPLEMENTATION
+#endif
+
+#ifndef NO_DIRENT_IMPLEMENTATION
+
+// Only the fields d_name and (as an XSI extension) d_ino are specified
+// in POSIX.1. Other than Linux, the d_type field is available mainly
+// only on BSD systems. The remaining fields are available on many, but
+// not all systems.
+static boolean IsDirectory(char *dir, struct dirent *de)
+{
+#if defined(_DIRENT_HAVE_D_TYPE)
+    if (de->d_type != DT_UNKNOWN && de->d_type != DT_LNK)
+    {
+        return de->d_type == DT_DIR;
+    }
+    else
+#endif
+    {
+        char *filename;
+        struct stat sb;
+        int result;
+
+        filename = M_StringJoin(dir, DIR_SEPARATOR_S, de->d_name, NULL);
+        result = stat(filename, &sb);
+        free(filename);
+
+        if (result != 0)
+        {
+            return false;
+        }
+
+        return S_ISDIR(sb.st_mode);
+    }
+}
+
+struct glob_s
+{
+    char **globs;
+    int num_globs;
+    int flags;
+    DIR *dir;
+    char *directory;
+    char *last_filename;
+    // These fields are only used when the GLOB_FLAG_SORTED flag is set:
+    char **filenames;
+    int filenames_len;
+    int next_index;
+};
+
+static void FreeStringList(char **globs, int num_globs)
+{
+    int i;
+    for (i = 0; i < num_globs; ++i)
+    {
+        free(globs[i]);
+    }
+    free(globs);
+}
+
+glob_t *I_StartMultiGlob(const char *directory, int flags,
+                         const char *glob, ...)
+{
+    char **globs;
+    int num_globs;
+    glob_t *result;
+    va_list args;
+
+    globs = malloc(sizeof(char *));
+    if (globs == NULL)
+    {
+        return NULL;
+    }
+    globs[0] = M_StringDuplicate(glob);
+    num_globs = 1;
+
+    va_start(args, glob);
+    for (;;)
+    {
+        const char *arg = va_arg(args, const char *);
+        char **new_globs;
+
+        if (arg == NULL)
+        {
+            break;
+        }
+
+        new_globs = realloc(globs, sizeof(char *) * (num_globs + 1));
+        if (new_globs == NULL)
+        {
+            FreeStringList(globs, num_globs);
+        }
+        globs = new_globs;
+        globs[num_globs] = M_StringDuplicate(arg);
+        ++num_globs;
+    }
+    va_end(args);
+
+    result = malloc(sizeof(glob_t));
+    if (result == NULL)
+    {
+        FreeStringList(globs, num_globs);
+        return NULL;
+    }
+
+    result->dir = opendir(directory);
+    if (result->dir == NULL)
+    {
+        FreeStringList(globs, num_globs);
+        free(result);
+        return NULL;
+    }
+
+    result->directory = M_StringDuplicate(directory);
+    result->globs = globs;
+    result->num_globs = num_globs;
+    result->flags = flags;
+    result->last_filename = NULL;
+    result->filenames = NULL;
+    result->filenames_len = 0;
+    result->next_index = -1;
+    return result;
+}
+
+glob_t *I_StartGlob(const char *directory, const char *glob, int flags)
+{
+    return I_StartMultiGlob(directory, flags, glob, NULL);
+}
+
+void I_EndGlob(glob_t *glob)
+{
+    if (glob == NULL)
+    {
+        return;
+    }
+
+    FreeStringList(glob->globs, glob->num_globs);
+    FreeStringList(glob->filenames, glob->filenames_len);
+
+    free(glob->directory);
+    free(glob->last_filename);
+    (void) closedir(glob->dir);
+    free(glob);
+}
+
+static boolean MatchesGlob(const char *name, const char *glob, int flags)
+{
+    int n, g;
+
+    while (*glob != '\0')
+    {
+        n = *name;
+        g = *glob;
+
+        if ((flags & GLOB_FLAG_NOCASE) != 0)
+        {
+            n = tolower(n);
+            g = tolower(g);
+        }
+
+        if (g == '*')
+        {
+            // To handle *-matching we skip past the * and recurse
+            // to check each subsequent character in turn. If none
+            // match then the whole match is a failure.
+            while (*name != '\0')
+            {
+                if (MatchesGlob(name, glob + 1, flags))
+                {
+                    return true;
+                }
+                ++name;
+            }
+            return glob[1] == '\0';
+        }
+        else if (g != '?' && n != g)
+        {
+            // For normal characters the name must match the glob,
+            // but for ? we don't care what the character is.
+            return false;
+        }
+
+        ++name;
+        ++glob;
+    }
+
+    // Match successful when glob and name end at the same time.
+    return *name == '\0';
+}
+
+static boolean MatchesAnyGlob(const char *name, glob_t *glob)
+{
+    int i;
+
+    for (i = 0; i < glob->num_globs; ++i)
+    {
+        if (MatchesGlob(name, glob->globs[i], glob->flags))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+static char *NextGlob(glob_t *glob)
+{
+    struct dirent *de;
+
+    do
+    {
+        de = readdir(glob->dir);
+        if (de == NULL)
+        {
+            return NULL;
+        }
+    } while (IsDirectory(glob->directory, de)
+          || !MatchesAnyGlob(de->d_name, glob));
+
+    // Return the fully-qualified path, not just the bare filename.
+    return M_StringJoin(glob->directory, DIR_SEPARATOR_S, de->d_name, NULL);
+}
+
+static void ReadAllFilenames(glob_t *glob)
+{
+    char *name;
+
+    glob->filenames = NULL;
+    glob->filenames_len = 0;
+    glob->next_index = 0;
+
+    for (;;)
+    {
+        name = NextGlob(glob);
+        if (name == NULL)
+        {
+            break;
+        }
+        glob->filenames = realloc(glob->filenames,
+                                  (glob->filenames_len + 1) * sizeof(char *));
+        glob->filenames[glob->filenames_len] = name;
+        ++glob->filenames_len;
+    }
+}
+
+static void SortFilenames(char **filenames, int len, int flags)
+{
+    char *pivot, *tmp;
+    int i, left_len, cmp;
+
+    if (len <= 1)
+    {
+        return;
+    }
+    pivot = filenames[len - 1];
+    left_len = 0;
+    for (i = 0; i < len-1; ++i)
+    {
+        if ((flags & GLOB_FLAG_NOCASE) != 0)
+        {
+            cmp = strcasecmp(filenames[i], pivot);
+        }
+        else
+        {
+            cmp = strcmp(filenames[i], pivot);
+        }
+
+        if (cmp < 0)
+        {
+            tmp = filenames[i];
+            filenames[i] = filenames[left_len];
+            filenames[left_len] = tmp;
+            ++left_len;
+        }
+    }
+    filenames[len - 1] = filenames[left_len];
+    filenames[left_len] = pivot;
+
+    SortFilenames(filenames, left_len, flags);
+    SortFilenames(&filenames[left_len + 1], len - left_len - 1, flags);
+}
+
+const char *I_NextGlob(glob_t *glob)
+{
+    const char *result;
+
+    if (glob == NULL)
+    {
+        return NULL;
+    }
+
+    // In unsorted mode we just return the filenames as we read
+    // them back from the system API.
+    if ((glob->flags & GLOB_FLAG_SORTED) == 0)
+    {
+        free(glob->last_filename);
+        glob->last_filename = NextGlob(glob);
+        return glob->last_filename;
+    }
+
+    // In sorted mode we read the whole list of filenames into memory,
+    // sort them and return them one at a time.
+    if (glob->next_index < 0)
+    {
+        ReadAllFilenames(glob);
+        SortFilenames(glob->filenames, glob->filenames_len, glob->flags);
+    }
+    if (glob->next_index >= glob->filenames_len)
+    {
+        return NULL;
+    }
+    result = glob->filenames[glob->next_index];
+    ++glob->next_index;
+    return result;
+}
+
+#else /* #ifdef NO_DIRENT_IMPLEMENTATION */
+
+#warning No native implementation of file globbing.
+
+glob_t *I_StartGlob(const char *directory, const char *glob, int flags)
+{
+    return NULL;
+}
+
+void I_EndGlob(glob_t *glob)
+{
+}
+
+const char *I_NextGlob(glob_t *glob)
+{
+    return "";
+}
+
+#endif /* #ifdef NO_DIRENT_IMPLEMENTATION */
+

--- a/src/i_glob.h
+++ b/src/i_glob.h
@@ -1,0 +1,49 @@
+//
+// Copyright(C) 2018 Simon Howard
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	System specific file globbing interface.
+//
+
+
+#pragma once
+
+enum {
+    GLOB_FLAG_NOCASE =  0x01,
+    GLOB_FLAG_SORTED =  0x02
+};
+
+typedef struct glob_s glob_t;
+
+/**
+ * Start reading a list of file paths from the given directory which match
+ * the given glob pattern. I_EndGlob() must be called on completion.
+ */
+glob_t *I_StartGlob(const char *directory, const char *glob, int flags);
+
+/**
+ * Same as I_StartGlob but multiple glob patterns can be provided. The list
+ * of patterns must be terminated with NULL.
+ */
+glob_t *I_StartMultiGlob(const char *directory, int flags, const char *glob, ...);
+
+/**
+ * Finish reading file list.
+ */
+void I_EndGlob(glob_t *glob);
+
+/**
+ * Read the name of the next globbed filename. NULL is returned if there
+ * are no more found.
+ */
+const char *I_NextGlob(glob_t *glob);

--- a/src/m_argv.c
+++ b/src/m_argv.c
@@ -389,6 +389,12 @@ printf("  %-34s  %s\n", (keys), english_language ? (description_eng) : (descript
                       "Specify <path> to level scripts. Development option",
                       "Задать путь к скриптам уровней. Опция для разработки");
     }
+    CLI_Parameter("-autoloadroot <dir>",
+                  "Specify root directory for autoload",
+                  "Задать корневую директорию для автозагрузки");
+    CLI_Parameter("-noautoload",
+                  "Disable auto-loading of WAD files",
+                  "Отключить автозагрузку WAD файлов");
     CLI_Parameter("-response <path>",
                   "Load extra command line arguments from the given response file",
                   "Загрузить дополнительные параметры командной строки из данного файла ответов");

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -111,57 +111,12 @@ static default_t defaults_list[] =
     CONFIG_VARIABLE_INT(english_language),
 
     //!
-    // [JN] Doom PWAD autoloading
-    //
+    // Full path to a directory in which WAD files and dehacked patches
+    // can be placed to be automatically loaded on startup. A subdirectory
+    // of this directory matching the IWAD name is checked to find the
+    // files to load.
 
-    CONFIG_VARIABLE_STRING(autoload_global_pwad1),
-    CONFIG_VARIABLE_STRING(autoload_global_pwad2),
-    CONFIG_VARIABLE_STRING(autoload_global_pwad3),
-    CONFIG_VARIABLE_STRING(autoload_global_pwad4),
-
-    CONFIG_VARIABLE_STRING(autoload_doom1_pwad1),
-    CONFIG_VARIABLE_STRING(autoload_doom1_pwad2),
-    CONFIG_VARIABLE_STRING(autoload_doom1_pwad3),
-    CONFIG_VARIABLE_STRING(autoload_doom1_pwad4),
-
-    CONFIG_VARIABLE_STRING(autoload_doom2_pwad1),
-    CONFIG_VARIABLE_STRING(autoload_doom2_pwad2),
-    CONFIG_VARIABLE_STRING(autoload_doom2_pwad3),
-    CONFIG_VARIABLE_STRING(autoload_doom2_pwad4),
-
-    CONFIG_VARIABLE_STRING(autoload_plutonia_pwad1),
-    CONFIG_VARIABLE_STRING(autoload_plutonia_pwad2),
-    CONFIG_VARIABLE_STRING(autoload_plutonia_pwad3),
-    CONFIG_VARIABLE_STRING(autoload_plutonia_pwad4),
-
-    CONFIG_VARIABLE_STRING(autoload_tnt_pwad1),
-    CONFIG_VARIABLE_STRING(autoload_tnt_pwad2),
-    CONFIG_VARIABLE_STRING(autoload_tnt_pwad3),
-    CONFIG_VARIABLE_STRING(autoload_tnt_pwad4),
-
-    CONFIG_VARIABLE_STRING(autoload_freedoom1_pwad1),
-    CONFIG_VARIABLE_STRING(autoload_freedoom1_pwad2),
-    CONFIG_VARIABLE_STRING(autoload_freedoom1_pwad3),
-    CONFIG_VARIABLE_STRING(autoload_freedoom1_pwad4),
-
-    CONFIG_VARIABLE_STRING(autoload_freedoom2_pwad1),
-    CONFIG_VARIABLE_STRING(autoload_freedoom2_pwad2),
-    CONFIG_VARIABLE_STRING(autoload_freedoom2_pwad3),
-    CONFIG_VARIABLE_STRING(autoload_freedoom2_pwad4),
-
-    //!
-    // [JN] Heretic PWAD autoloading
-    //
-
-    CONFIG_VARIABLE_STRING(autoload_registered_pwad1),
-    CONFIG_VARIABLE_STRING(autoload_registered_pwad2),
-    CONFIG_VARIABLE_STRING(autoload_registered_pwad3),
-    CONFIG_VARIABLE_STRING(autoload_registered_pwad4),
-
-    CONFIG_VARIABLE_STRING(autoload_retail_pwad1),
-    CONFIG_VARIABLE_STRING(autoload_retail_pwad2),
-    CONFIG_VARIABLE_STRING(autoload_retail_pwad3),
-    CONFIG_VARIABLE_STRING(autoload_retail_pwad4),
+    CONFIG_VARIABLE_STRING(autoload_root),
 
     //!
     // @game strife

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -314,6 +314,36 @@ char *M_DirName(const char *path)
     }
 }
 
+/**
+ * Returns the filename described by the given path (without the directory name).
+ * The result points inside path and nothing new is allocated.
+ */
+const char *M_FileName(const char *path)
+{
+    const char *pf, *pb;
+
+    pf = strrchr(path, '/');
+#ifdef _WIN32
+    pb = strrchr(path, '\\');
+    // [FG] allow C:filename
+    if (pf == NULL && pb == NULL)
+    {
+        pb = strrchr(path, ':');
+    }
+#else
+    pb = NULL;
+#endif
+    if (pf == NULL && pb == NULL)
+    {
+        return path;
+    }
+    else
+    {
+        const char *p = MAX(pf, pb);
+        return p + 1;
+    }
+}
+
 void M_ExtractFileBase(char *path, char *dest)
 {
     char *src;

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -35,6 +35,7 @@ char *M_FileCaseExists(char *file);
 long M_FileLength(FILE *handle);
 boolean M_StrToInt(const char *str, int *result);
 char *M_DirName(const char *path);
+const char *M_FileName(const char *path);
 void M_ExtractFileBase(char *path, char *dest);
 void M_ForceUppercase(char *text);
 void M_ForceLowercase(char *text);

--- a/src/rd_io.h
+++ b/src/rd_io.h
@@ -18,17 +18,18 @@
 #pragma once
 
 #include <stdio.h>
+#include <sys/stat.h>
 
 
 #ifdef _WIN32
 #include <io.h>
-#include <sys/stat.h>
 #include <direct.h>
 
 wchar_t* ConvertToUtf8(const char *str);
 FILE* D_fopen(const char *filename, const char *mode);
 int D_remove(const char *path);
 int D_rename(const char *oldname, const char *newname);
+int D_stat(const char *path, struct stat *buf);
 int D_mkdir(const char *dirname);
 
 #undef  fopen
@@ -40,10 +41,10 @@ int D_mkdir(const char *dirname);
 #undef  rename
 #define rename(o, n) D_rename(o, n)
 
-// [Dasperal] not used
-// #undef  stat
-// #define stat(p, b) D_stat(p, b)
+#undef  stat
+#define stat(p, b) D_stat(p, b)
 
+// [Dasperal] not used
 // #undef  open
 // #define open(n, of) D_open(n, of)
 

--- a/src/win_compat.c
+++ b/src/win_compat.c
@@ -135,6 +135,31 @@ int D_rename(const char *oldname, const char *newname)
     return ret;
 }
 
+int D_stat(const char *path, struct stat *buf)
+{
+    wchar_t *wpath = NULL;
+    struct _stat wbuf;
+    int ret;
+
+    wpath = ConvertToUtf8(path);
+
+    if (!wpath)
+    {
+        return -1;
+    }
+
+    ret = _wstat(wpath, &wbuf);
+
+    // The _wstat() function expects a struct _stat* parameter that is
+    // incompatible with struct stat*. We copy only the required compatible
+    // field.
+    buf->st_mode = wbuf.st_mode;
+
+    free(wpath);
+
+    return ret;
+}
+
 int D_mkdir(const char *dirname)
 {
     wchar_t *wdir;

--- a/src/win_opendir.c
+++ b/src/win_opendir.c
@@ -1,0 +1,335 @@
+//
+// 03/10/2006 James Haley
+//
+// For this module only: 
+// This code is public domain. No change sufficient enough to constitute a
+// significant or original work has been made, and thus it remains as such.
+//
+//
+// DESCRIPTION:
+//
+// Implementation of POSIX opendir for Visual C++.
+// Derived from the MinGW C Library Extensions Source (released to the
+// public domain). As with other Win32 modules, don't include most DOOM
+// headers into this or conflicts will occur.
+//
+// Original Header:
+//
+// * dirent.c
+// * This file has no copyright assigned and is placed in the Public Domain.
+// * This file is a part of the mingw-runtime package.
+// * No warranty is given; refer to the file DISCLAIMER within the package.
+// *
+// * Derived from DIRLIB.C by Matt J. Weinstein 
+// * This note appears in the DIRLIB.H
+// * DIRLIB.H by M. J. Weinstein   Released to public domain 1-Jan-89
+// *
+// * Updated by Jeremy Bettis <jeremy@hksys.com>
+// * Significantly revised and rewinddir, seekdir and telldir added by Colin
+// * Peters <colin@fu.is.saga-u.ac.jp>
+//
+
+#ifndef _MSC_VER
+#error i_opndir.c is for Microsoft Visual C++ only
+#endif
+
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h> /* for GetFileAttributes */
+
+#include <tchar.h>
+#define SUFFIX	_T("*")
+#define	SLASH	_T("\\")
+
+#include "win_opendir.h"
+
+//
+// opendir
+// 
+// Returns a pointer to a DIR structure appropriately filled in to begin
+// searching a directory.
+//
+DIR *opendir(const _TCHAR *szPath)
+{
+   DIR *nd;
+   unsigned int rc;
+   _TCHAR szFullPath[MAX_PATH];
+	
+   errno = 0;
+   
+   if(!szPath)
+   {
+      errno = EFAULT;
+      return (DIR *)0;
+   }
+   
+   if(szPath[0] == _T('\0'))
+   {
+      errno = ENOTDIR;
+      return (DIR *)0;
+   }
+
+   /* Attempt to determine if the given path really is a directory. */
+   rc = GetFileAttributes(szPath);
+   if(rc == (unsigned int)-1)
+   {
+      /* call GetLastError for more error info */
+      errno = ENOENT;
+      return (DIR *)0;
+   }
+   if(!(rc & FILE_ATTRIBUTE_DIRECTORY))
+   {
+      /* Error, entry exists but not a directory. */
+      errno = ENOTDIR;
+      return (DIR *)0;
+   }
+
+   /* Make an absolute pathname.  */
+   _tfullpath(szFullPath, szPath, MAX_PATH);
+
+   /* Allocate enough space to store DIR structure and the complete
+   * directory path given. */
+   nd = (DIR *)(malloc(sizeof(DIR) + (_tcslen(szFullPath)
+                                       + _tcslen(SLASH)
+                                       + _tcslen(SUFFIX) + 1)
+                                     * sizeof(_TCHAR)));
+
+   if(!nd)
+   {
+      /* Error, out of memory. */
+      errno = ENOMEM;
+      return (DIR *)0;
+   }
+
+   /* Create the search expression. */
+   _tcscpy(nd->dd_name, szFullPath);
+
+   /* Add on a slash if the path does not end with one. */
+   if(nd->dd_name[0] != _T('\0')
+      && _tcsrchr(nd->dd_name, _T('/'))  != nd->dd_name
+					    + _tcslen(nd->dd_name) - 1
+      && _tcsrchr(nd->dd_name, _T('\\')) != nd->dd_name
+      					    + _tcslen(nd->dd_name) - 1)
+   {
+      _tcscat(nd->dd_name, SLASH);
+   }
+
+   /* Add on the search pattern */
+   _tcscat(nd->dd_name, SUFFIX);
+   
+   /* Initialize handle to -1 so that a premature closedir doesn't try
+   * to call _findclose on it. */
+   nd->dd_handle = -1;
+
+   /* Initialize the status. */
+   nd->dd_stat = 0;
+
+   /* Initialize the dirent structure. ino and reclen are invalid under
+    * Win32, and name simply points at the appropriate part of the
+    * findfirst_t structure. */
+   nd->dd_dir.d_ino = 0;
+   nd->dd_dir.d_reclen = 0;
+   nd->dd_dir.d_namlen = 0;
+   memset(nd->dd_dir.d_name, 0, FILENAME_MAX);
+  
+   return nd;
+}
+
+//
+// readdir
+//
+// Return a pointer to a dirent structure filled with the information on the
+// next entry in the directory.
+//
+struct dirent *readdir(DIR *dirp)
+{
+   errno = 0;
+   
+   /* Check for valid DIR struct. */
+   if(!dirp)
+   {
+      errno = EFAULT;
+      return (struct dirent *)0;
+   }
+
+   if (dirp->dd_stat < 0)
+   {
+     /* We have already returned all files in the directory
+      * (or the structure has an invalid dd_stat). */
+      return (struct dirent *)0;
+   }
+   else if (dirp->dd_stat == 0)
+   {
+      /* We haven't started the search yet. */
+      /* Start the search */
+      dirp->dd_handle = _tfindfirst(dirp->dd_name, &(dirp->dd_dta));
+
+      if(dirp->dd_handle == -1)
+      {
+         /* Whoops! Seems there are no files in that
+          * directory. */
+         dirp->dd_stat = -1;
+      }
+      else
+      {
+         dirp->dd_stat = 1;
+      }
+   }
+   else
+   {
+      /* Get the next search entry. */
+      if(_tfindnext(dirp->dd_handle, &(dirp->dd_dta)))
+      {
+         /* We are off the end or otherwise error.	
+            _findnext sets errno to ENOENT if no more file
+            Undo this. */ 
+         DWORD winerr = GetLastError();
+         if(winerr == ERROR_NO_MORE_FILES)
+            errno = 0;
+         _findclose(dirp->dd_handle);
+         dirp->dd_handle = -1;
+         dirp->dd_stat = -1;
+      }
+      else
+      {
+         /* Update the status to indicate the correct
+          * number. */
+         dirp->dd_stat++;
+      }
+   }
+
+   if (dirp->dd_stat > 0)
+   {
+      /* Successfully got an entry. Everything about the file is
+       * already appropriately filled in except the length of the
+       * file name. */
+      dirp->dd_dir.d_namlen = _tcslen(dirp->dd_dta.name);
+      _tcscpy(dirp->dd_dir.d_name, dirp->dd_dta.name);
+      return &dirp->dd_dir;
+   }
+
+   return (struct dirent *)0;
+}
+
+
+//
+// closedir
+//
+// Frees up resources allocated by opendir.
+//
+int closedir(DIR *dirp)
+{
+   int rc;
+   
+   errno = 0;
+   rc = 0;
+   
+   if(!dirp)
+   {
+      errno = EFAULT;
+      return -1;
+   }
+
+   if(dirp->dd_handle != -1)
+   {
+      rc = _findclose(dirp->dd_handle);
+   }
+
+   /* Delete the dir structure. */
+   free(dirp);
+   
+   return rc;
+}
+
+//
+// rewinddir
+//
+// Return to the beginning of the directory "stream". We simply call findclose
+// and then reset things like an opendir.
+//
+void rewinddir(DIR * dirp)
+{
+   errno = 0;
+   
+   if(!dirp)
+   {
+      errno = EFAULT;
+      return;
+   }
+
+   if(dirp->dd_handle != -1)
+   {
+      _findclose(dirp->dd_handle);
+   }
+   
+   dirp->dd_handle = -1;
+   dirp->dd_stat = 0;
+}
+
+//
+// telldir
+//
+// Returns the "position" in the "directory stream" which can be used with
+// seekdir to go back to an old entry. We simply return the value in stat.
+//
+long telldir(DIR *dirp)
+{
+   errno = 0;
+   
+   if(!dirp)
+   {
+      errno = EFAULT;
+      return -1;
+   }
+   return dirp->dd_stat;
+}
+
+//
+// seekdir
+//
+// Seek to an entry previously returned by telldir. We rewind the directory
+// and call readdir repeatedly until either dd_stat is the position number
+// or -1 (off the end). This is not perfect, in that the directory may
+// have changed while we weren't looking. But that is probably the case with
+// any such system.
+//
+void seekdir(DIR *dirp, long lPos)
+{
+   errno = 0;
+   
+   if(!dirp)
+   {
+      errno = EFAULT;
+      return;
+   }
+
+   if(lPos < -1)
+   {
+      /* Seeking to an invalid position. */
+      errno = EINVAL;
+      return;
+   }
+   else if(lPos == -1)
+   {
+      /* Seek past end. */
+      if(dirp->dd_handle != -1)
+      {
+         _findclose(dirp->dd_handle);
+      }
+      dirp->dd_handle = -1;
+      dirp->dd_stat = -1;
+   }
+   else
+   {
+      /* Rewind and read forward to the appropriate index. */
+      rewinddir(dirp);
+      
+      while((dirp->dd_stat < lPos) && readdir(dirp))
+         ; /* do-nothing loop */
+   }
+}
+
+// EOF

--- a/src/win_opendir.h
+++ b/src/win_opendir.h
@@ -1,0 +1,70 @@
+//
+// 03/10/2006 James Haley
+//
+// For this module only: 
+// This code is public domain. No change sufficient enough to constitute a
+// significant or original work has been made, and thus it remains as such.
+//
+//
+// DESCRIPTION:
+//
+// Implementation of POSIX opendir for Visual C++.
+// Derived from the MinGW C Library Extensions Source (released to the
+//  public domain).
+//
+
+#pragma once
+
+#include <io.h>
+
+#ifndef FILENAME_MAX
+#define FILENAME_MAX 260
+#endif
+
+struct dirent
+{
+   long		  d_ino;    /* Always zero. */
+   unsigned short d_reclen; /* Always zero. */
+   unsigned short d_namlen; /* Length of name in d_name. */
+   char           d_name[FILENAME_MAX]; /* File name. */
+};
+
+/*
+ * This is an internal data structure. Good programmers will not use it
+ * except as an argument to one of the functions below.
+ * dd_stat field is now int (was short in older versions).
+ */
+typedef struct
+{
+   /* disk transfer area for this dir */
+   struct _finddata_t dd_dta;
+
+   /* dirent struct to return from dir (NOTE: this makes this thread
+    * safe as long as only one thread uses a particular DIR struct at
+    * a time) */
+   struct dirent dd_dir;
+
+   /* _findnext handle */
+   intptr_t	dd_handle;
+
+   /*
+    * Status of search:
+    *   0 = not started yet (next entry to read is first entry)
+    *  -1 = off the end
+    *   positive = 0 based index of next entry
+    */
+   int dd_stat;
+
+   /* given path for dir with search pattern (struct is extended) */
+   char dd_name[1];
+} DIR;
+
+DIR *opendir(const char *);
+struct dirent *readdir(DIR *);
+int closedir(DIR *);
+void rewinddir(DIR *);
+long telldir(DIR *);
+void seekdir(DIR *, long);
+
+// EOF
+


### PR DESCRIPTION
Resolves #388

Replaced `autoload_*_*` config variables with directory based autoload like in Crispy Doom.

Set `autoload_root` config variable to the path to autoload root directory or provide it with `-autoloadroot <dir>` command line parameter. Navigate to the specified directory, create a subdirectory with the name of wad (e.g. `doom.wad`) for which you want to autoload files and place PWADs and/or Dehacked patches in this subdirectory.
Autoload applied only for explicitly specified wads (e.g. IWAD or PWADs, loaded via `-file <path> ...` command line parameter).
To disable autoload, use `-noautoload` command line parameter.

Loading order:
1) Explicitly specified wad
2) Associated internal resources
3) Associated autoloaded files in unspecified order
4) Next explicitly specified wad