### PR TITLE
Use `uint64_t` values in `GetAdjustedTimeN`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ else()
     string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 endif()
 
-find_package(SDL2 2.0.16 REQUIRED)
+find_package(SDL2 2.0.18 REQUIRED)
 find_package(SDL2_mixer 2.0.2 REQUIRED)
 find_package(SDL2_net 2.0.0 REQUIRED)
 find_package(samplerate)

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -134,11 +134,11 @@ static int player_class;
 // 35 fps clock adjusted by offsetms milliseconds
 // [crispy] variable rendering framerate
 
-int GetAdjustedTimeN(const int N)
+uint64_t GetAdjustedTimeN(const int N)
 {
-    int time_ms;
+    uint64_t time_ms;
 
-    time_ms = I_GetTimeMS();
+    time_ms = I_GetTimeMS64();
 
     if (new_sync)
     {
@@ -151,7 +151,7 @@ int GetAdjustedTimeN(const int N)
     return (time_ms * N) / 1000;
 }
 
-static int GetAdjustedTime(void)
+static uint64_t GetAdjustedTime(void)
 {
     return GetAdjustedTimeN(TICRATE);
 }

--- a/src/i_timer.c
+++ b/src/i_timer.c
@@ -62,6 +62,18 @@ int I_GetTimeMS(void)
     return ticks - basetime;
 }
 
+unsigned long long I_GetTimeMS64(void)
+{
+    Uint64 ticks;
+
+    ticks = SDL_GetTicks64();
+
+    if (basetime == 0)
+        basetime = ticks;
+
+    return ticks - basetime;
+}
+
 // Sleep for a specified number of ms
 
 void I_Sleep(int ms)

--- a/src/i_timer.h
+++ b/src/i_timer.h
@@ -31,6 +31,7 @@ int I_GetTime (void);
 
 // returns current time in ms
 int I_GetTimeMS (void);
+unsigned long long I_GetTimeMS64 (void);
 
 // Pause for a specified number of ms
 void I_Sleep(int ms);

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -921,7 +921,7 @@ void I_FinishUpdate (void)
     {
         static int halftics_old;
         int halftics;
-        extern int GetAdjustedTimeN (const int N);
+        extern uint64_t GetAdjustedTimeN(const int N);
 
         while ((halftics = GetAdjustedTimeN(max_fps)) == halftics_old)
         {


### PR DESCRIPTION
This should fix renderer freeze after playing about ~30 consecutive hours without VSync enabled.