### PR TITLE
CI Update

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,6 +56,7 @@ jobs:
     steps:
       - name: Setup MSYS env
         if: matrix.os.name == 'Windows'
+        timeout-minutes: 10
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.compiler.msys_msystem_prefix }}${{ matrix.arch.msys_bits }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -96,7 +96,7 @@ jobs:
                 $build_portable \
                 -S . -B build
           sha_short=$(echo ${{ github.sha }} | cut -c1-7)
-          echo "::set-output name=sha_short::$sha_short"
+          echo "sha_short=$sha_short" >> $GITHUB_OUTPUT
 
       - name: Build
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -80,7 +80,7 @@ jobs:
           sudo apt-get install ${{ matrix.compiler.name }} gdb ninja-build python3 cmake \
                                libsdl2-dev libsdl2-net-dev libsdl2-mixer-dev libpng-dev libsamplerate-dev
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure
         id: configure
@@ -132,7 +132,7 @@ jobs:
           github.event_name == 'push' &&
           github.ref == 'refs/heads/master' &&
           matrix.os.name == 'Windows'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: inter-doom-6.x.x-${{ steps.configure.outputs.sha_short }}-windows-${{ matrix.arch.name }}-${{ matrix.compiler.display_name }}
           path: ./build/install/

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -54,7 +54,7 @@ jobs:
             ${{ matrix.compiler.msys_package_prefix }}-${{ matrix.arch.msys_name }}-libsamplerate
             ${{ matrix.compiler.msys_package_prefix }}-${{ matrix.arch.msys_name }}-libpng
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure
         id: configure

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - name: Setup MSYS env
         if: ${{ matrix.os.name == 'Windows' }}
+        timeout-minutes: 10
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.compiler.msys_msystem_prefix }}${{ matrix.arch.bits }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -82,8 +82,8 @@ jobs:
               game="doom"
               version="${{ github.ref_name }}"
           fi
-          echo "::set-output name=game::$game"
-          echo "::set-output name=version::$version"
+          echo "game=$game" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_OUTPUT
           cmake -G "Ninja" -D COMPILE_DOOM="$compile_doom" -D COMPILE_HERETIC="$compile_heretic" -D COMPILE_HEXEN="$compile_hexen" -D COMPILE_STRIFE="$compile_strife" -D BUILD_VERSION_OVERWRITE="$version" -D CMAKE_BUILD_TYPE=Release -S . -B build
 
       - name: Build

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -3,7 +3,7 @@ name: Update Wiki
 on:
   push:
     branches: ["master"]
-    paths: ["src/m_argv.c"]
+    paths: ["src/m_argv.c", "man/docgen.py", ".github/wiki_templates/*", ".github/workflows/update-wiki.yml"]
 
 jobs:
   Update-Wiki:

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -14,11 +14,11 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: code
       - name: Checkout wiki
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{github.repository}}.wiki
           path: wiki


### PR DESCRIPTION
* Get rid of deprecated stuff
  * https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
  * https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* Set timeout for `Setup MSYS env` to 10 minutes
* Run `update-wiki` if any related file was updated