### PR TITLE
Config migration and Hexen "Detail level" bind

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1892,7 +1892,7 @@ static void M_RD_Draw_Rendering_2 (void)
         RD_M_DrawTextSmallENG(window_ontop ? "on" : "off", 139 + wide_delta, 65, CR_NONE);
 
         // Preserve window aspect ratio
-        RD_M_DrawTextSmallENG(aspect_ratio_correct ? "on" : "off", 246 + wide_delta, 75, CR_NONE);
+        RD_M_DrawTextSmallENG(preserve_window_aspect_ratio ? "on" : "off", 246 + wide_delta, 75, CR_NONE);
 
         // Show disk icon
         RD_M_DrawTextSmallENG(show_diskicon == 1 ? "bottom" :
@@ -1946,7 +1946,7 @@ static void M_RD_Draw_Rendering_2 (void)
         RD_M_DrawTextSmallRUS(window_ontop ? "drk" : "dsrk", 182 + wide_delta, 65, CR_NONE);
 
         // Пропорции окна
-        RD_M_DrawTextSmallRUS(aspect_ratio_correct  ? "abrcbhjdfyyst" : "cdj,jlyst", 152 + wide_delta, 75, CR_NONE);
+        RD_M_DrawTextSmallRUS(preserve_window_aspect_ratio  ? "abrcbhjdfyyst" : "cdj,jlyst", 152 + wide_delta, 75, CR_NONE);
 
         // Отображать значок дискеты
         RD_M_DrawTextSmallRUS(show_diskicon == 1 ? "cybpe" :
@@ -2152,7 +2152,7 @@ static void M_RD_Change_AlwaysOnTop()
 
 static void M_RD_Change_WindowAspectRatio()
 {
-    aspect_ratio_correct ^= 1;
+    preserve_window_aspect_ratio ^= 1;
     
     I_ReInitGraphics(REINIT_RENDERER | REINIT_TEXTURES | REINIT_ASPECTRATIO);
 }
@@ -6138,16 +6138,16 @@ static void M_RD_BackToDefaults_Recommended(int choice)
     static char resetmsg[24];
 
     // Rendering
-    vsync                   = 1;
-    aspect_ratio_correct    = 1;
-    max_fps                 = 200; uncapped_fps = 1;
-    show_fps                = 0;
-    smoothing               = 0;
-    vga_porch_flash         = 0;
-    smoothlight             = 1;
-    show_diskicon           = 1;
-    screen_wiping           = 1;
-    png_screenshots         = 1;
+    vsync                        = 1;
+    preserve_window_aspect_ratio = 1;
+    max_fps                      = 200; uncapped_fps = 1;
+    show_fps                     = 0;
+    smoothing                    = 0;
+    vga_porch_flash              = 0;
+    smoothlight                  = 1;
+    show_diskicon                = 1;
+    screen_wiping                = 1;
+    png_screenshots              = 1;
 
     // Display
     screenblocks          = 10;
@@ -6332,16 +6332,16 @@ static void M_RD_BackToDefaults_Original(int choice)
     static char resetmsg[24];
 
     // Rendering
-    vsync                   = 1;
-    aspect_ratio_correct    = 1;
-    max_fps                 = 35; uncapped_fps = 0;
-    show_fps                = 0;
-    smoothing               = 0;
-    vga_porch_flash         = 0;
-    smoothlight             = 0;
-    show_diskicon           = 1;
-    screen_wiping           = 1;
-    png_screenshots         = 1;
+    vsync                        = 1;
+    preserve_window_aspect_ratio = 1;
+    max_fps                      = 35; uncapped_fps = 0;
+    show_fps                     = 0;
+    smoothing                    = 0;
+    vga_porch_flash              = 0;
+    smoothlight                  = 0;
+    show_diskicon                = 1;
+    screen_wiping                = 1;
+    png_screenshots              = 1;
 
     // Display
     screenblocks          = 10;

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -2194,7 +2194,7 @@ static void DrawRenderingMenu2(void)
         RD_M_DrawTextSmallENG(window_ontop ? "ON" : "OFF", 138 + wide_delta, 72, CR_NONE);
 
         // Preserve window aspect ratio
-        RD_M_DrawTextSmallENG(aspect_ratio_correct ? "ON" : "OFF", 249 + wide_delta, 82, CR_NONE);
+        RD_M_DrawTextSmallENG(preserve_window_aspect_ratio ? "ON" : "OFF", 249 + wide_delta, 82, CR_NONE);
 
         // Show ENDTEXT screen
         RD_M_DrawTextSmallENG(show_endoom ? "ON" : "OFF", 188 + wide_delta, 112, CR_NONE);
@@ -2230,7 +2230,7 @@ static void DrawRenderingMenu2(void)
         RD_M_DrawTextSmallRUS(window_ontop ? "DRK" : "DSRK", 177 + wide_delta, 72, CR_NONE);
 
         // Пропорции окна
-        RD_M_DrawTextSmallRUS(aspect_ratio_correct  ? "ABRCBHJDFYYST" : "CDJ,JLYST", 147 + wide_delta, 82, CR_NONE);
+        RD_M_DrawTextSmallRUS(preserve_window_aspect_ratio  ? "ABRCBHJDFYYST" : "CDJ,JLYST", 147 + wide_delta, 82, CR_NONE);
 
         // Показывать экран ENDTEXT
         RD_M_DrawTextSmallENG("ENDTEXT:", 160 + wide_delta, 112, CR_NONE);
@@ -2421,7 +2421,7 @@ static void M_RD_AlwaysOnTop()
 
 static void M_RD_WindowAspectRatio()
 {
-    aspect_ratio_correct ^= 1;
+    preserve_window_aspect_ratio ^= 1;
     
     I_ReInitGraphics(REINIT_RENDERER | REINIT_TEXTURES | REINIT_ASPECTRATIO);
 }
@@ -5642,14 +5642,14 @@ static void M_RD_EndGame(int option)
 static void M_RD_BackToDefaults_Recommended(void)
 {
     // Rendering
-    vsync                   = 1;
-    aspect_ratio_correct    = 1;
-    max_fps                 = 200; uncapped_fps = 1;
-    show_fps                = 0;
-    smoothing               = 0;
-    vga_porch_flash         = 0;
-    smoothlight             = 1;
-    png_screenshots         = 1;
+    vsync                        = 1;
+    preserve_window_aspect_ratio = 1;
+    max_fps                      = 200; uncapped_fps = 1;
+    show_fps                     = 0;
+    smoothing                    = 0;
+    vga_porch_flash              = 0;
+    smoothlight                  = 1;
+    png_screenshots              = 1;
 
     // Display
     screenblocks        = 10;
@@ -5801,14 +5801,14 @@ static void M_RD_BackToDefaults_Recommended(void)
 static void M_RD_BackToDefaults_Original(void)
 {
     // Rendering
-    vsync                   = 1;
-    aspect_ratio_correct    = 1;
-    max_fps                 = 35; uncapped_fps = 0;
-    show_fps                = 0;
-    smoothing               = 0;
-    vga_porch_flash         = 0;
-    smoothlight             = 0;
-    png_screenshots         = 1;
+    vsync                        = 1;
+    preserve_window_aspect_ratio = 1;
+    max_fps                      = 35; uncapped_fps = 0;
+    show_fps                     = 0;
+    smoothing                    = 0;
+    vga_porch_flash              = 0;
+    smoothlight                  = 0;
+    png_screenshots              = 1;
 
     // Display
     screenblocks        = 10;

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -184,6 +184,16 @@ int automap_grid = 0;
 int automap_grid_size = 128;
 int automap_mark_color = 3;
 
+// Stats
+int stats_placement = 0;
+int stats_kis = 1;
+int stats_skill = 0;
+int stats_level_time = 1;
+int stats_total_time = 0;
+int stats_coords = 0;
+int stats_level_name = 0;
+int stats_color = 1;
+
 // Sound
 int snd_monomode = 0;
 

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -5457,13 +5457,13 @@ static void DrawOptions2Menu_Vanilla(void)
 void M_RD_BackToDefaults_Recommended (void)
 {
     // Rendering
-    vsync                   = 1;
-    aspect_ratio_correct    = 1;
-    max_fps                 = 200; uncapped_fps = 1;
-    show_fps                = 0;
-    smoothing               = 0;
-    vga_porch_flash         = 0;
-    png_screenshots         = 1;
+    vsync                        = 1;
+    preserve_window_aspect_ratio = 1;
+    max_fps                      = 200; uncapped_fps = 1;
+    show_fps                     = 0;
+    smoothing                    = 0;
+    vga_porch_flash              = 0;
+    png_screenshots              = 1;
 
     // Display
     screenblocks           = 10;
@@ -5572,13 +5572,13 @@ void M_RD_BackToDefaults_Recommended (void)
 static void M_RD_BackToDefaults_Original(void)
 {
     // Rendering
-    vsync                   = 1;
-    aspect_ratio_correct    = 1;
-    max_fps                 = 35; uncapped_fps = 1;
-    show_fps                = 0;
-    smoothing               = 0;
-    vga_porch_flash         = 0;
-    png_screenshots         = 1;
+    vsync                        = 1;
+    preserve_window_aspect_ratio = 1;
+    max_fps                      = 35; uncapped_fps = 1;
+    show_fps                     = 0;
+    smoothing                    = 0;
+    vga_porch_flash              = 0;
+    png_screenshots              = 1;
 
     // Display
     screenblocks           = 10;

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -880,7 +880,7 @@ static MenuItem_t Bindings3Items[] = {
     I_EFUNC("Open save menu",     "cj[hfytybt buhs",     BK_StartBindingKey, bk_menu_save),   // Сохранение игры
     I_EFUNC("Open load menu",     "pfuheprf buhs",       BK_StartBindingKey, bk_menu_load),   // Загрузка игры
     I_EFUNC("Open volume menu",   "yfcnhjqrb uhjvrjcnb", BK_StartBindingKey, bk_menu_volume), // Настройки громкости
-    I_EFUNC("Suicide",            "Cebwbl",              BK_StartBindingKey, bk_detail),      // СУИЦИД
+    I_EFUNC("Suicide",            "Cebwbl",              BK_StartBindingKey, bk_suicide),      // СУИЦИД
     I_EFUNC("QUICK SAVE",         ",SCNHJT CJ[HFYTYBT",  BK_StartBindingKey, bk_qsave),       // Быстрое сохранение
     I_EFUNC("End game",           "pfrjyxbnm buhe",      BK_StartBindingKey, bk_end_game),    // Закончить игру
     I_EFUNC("QUICK LOAD",         ",SCNHFZ PFUHEPRF",    BK_StartBindingKey, bk_qload),       // Быстрая загрузка
@@ -6224,7 +6224,7 @@ boolean MN_Responder(event_t * event)
             slottextloaded = false; //reload the slot text, when needed
             return true;
         }
-        else if (BK_isKeyDown(event, bk_detail))         // F5 (suicide)
+        else if (BK_isKeyDown(event, bk_suicide))         // F5 (suicide)
         {
             // [JN] Allow to invoke only in game level state,
             // and only if player is alive.
@@ -6235,6 +6235,13 @@ boolean MN_Responder(event_t * event)
                 askforquit = true;
                 typeofask = 5;  // suicide
             }
+            return true;
+        }
+        else if (BK_isKeyDown(event, bk_detail))         // detail
+        {
+            // [JN] Restored variable detail mode.
+            M_RD_Detail();
+            S_StartSound(NULL, SFX_DOOR_LIGHT_CLOSE);
             return true;
         }
         else if (BK_isKeyDown(event, bk_qsave))          // F6 (quicksave)

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -170,7 +170,7 @@ int vsync = true;
 
 // Aspect ratio correction mode
 
-int aspect_ratio_correct = true;
+int preserve_window_aspect_ratio = true;
 int actualheight;
 
 // [JN] Show FPS counter
@@ -363,11 +363,11 @@ static void SetShowCursor (const boolean show)
     }
 }
 
-// Adjust window_width / window_height variables to be an an aspect
-// ratio consistent with the aspect_ratio_correct variable.
+// Adjust window_width / window_height variables to be an aspect
+// ratio consistent with the preserve_window_aspect_ratio variable.
 void AdjustWindowSize(void)
 {
-    if (aspect_ratio_correct)
+    if (preserve_window_aspect_ratio)
     {
         switch(changedWindowSize)
         {
@@ -1552,7 +1552,7 @@ static void SetVideoMode(void)
     // time this also defines the aspect ratio that is preserved while scaling
     // and stretching the texture into the window.
 
-    if (aspect_ratio_correct)
+    if (preserve_window_aspect_ratio)
     {
         SDL_RenderSetLogicalSize(renderer,
                                 screenwidth,
@@ -1815,7 +1815,7 @@ void I_ReInitGraphics (const int reinit)
 	// [crispy] re-set logical rendering resolution
 	if (reinit & REINIT_ASPECTRATIO)
 	{
-		if (aspect_ratio_correct == 1)
+		if (preserve_window_aspect_ratio == 1)
 		{
  			if (aspect_ratio == 1)
  			actualheight = SCREENHEIGHT_5_4;
@@ -1827,7 +1827,7 @@ void I_ReInitGraphics (const int reinit)
 			actualheight = SCREENHEIGHT;
 		}
 
-		if (aspect_ratio_correct)
+		if (preserve_window_aspect_ratio)
 		{
 			SDL_RenderSetLogicalSize(renderer,
 			                         screenwidth,
@@ -1891,7 +1891,7 @@ void I_RenderReadPixels(byte **data, int *w, int *h)
 	// [crispy] adjust cropping rectangle if necessary
 	rect.x = rect.y = 0;
 	SDL_GetRendererOutputSize(renderer, &rect.w, &rect.h);
-	if (aspect_ratio_correct)
+	if (preserve_window_aspect_ratio)
 	{
 		if (rect.w * actualheight > rect.h * screenwidth)
 		{
@@ -1932,31 +1932,31 @@ void I_RenderReadPixels(byte **data, int *w, int *h)
 // file system.
 void I_BindVideoVariables(void)
 {
-    M_BindIntVariable("use_mouse",                 &usemouse);
-    M_BindIntVariable("fullscreen",                &fullscreen);
-    M_BindIntVariable("aspect_ratio",              &aspect_ratio);
-    M_BindIntVariable("opengles_renderer",         &opengles_renderer);
-    M_BindIntVariable("video_display",             &video_display);
-    M_BindIntVariable("vsync",                     &vsync);
-    M_BindIntVariable("show_fps",                  &show_fps);
-    M_BindIntVariable("aspect_ratio_correct",      &aspect_ratio_correct);
-    M_BindIntVariable("smoothing",                 &smoothing);
-    M_BindIntVariable("max_fps",                   &max_fps);
-    M_BindIntVariable("vga_porch_flash",           &vga_porch_flash);
-    M_BindIntVariable("startup_delay",             &startup_delay);
-    M_BindIntVariable("resize_delay",              &resize_delay);
-    M_BindIntVariable("fullscreen_width",          &fullscreen_width);
-    M_BindIntVariable("fullscreen_height",         &fullscreen_height);
-    M_BindIntVariable("window_title_short",        &window_title_short);
-    M_BindIntVariable("window_width",              &window_width);
-    M_BindIntVariable("window_height",             &window_height);
-    M_BindIntVariable("window_border",             &window_border);
-    M_BindIntVariable("window_ontop",              &window_ontop);
-    M_BindIntVariable("grabmouse",                 &grabmouse);
-    M_BindStringVariable("video_driver",           &video_driver);
-    M_BindIntVariable("window_position_x",         &window_position_x);
-    M_BindIntVariable("window_position_y",         &window_position_y);
-    M_BindIntVariable("png_screenshots",           &png_screenshots);
+    M_BindIntVariable("use_mouse",                   &usemouse);
+    M_BindIntVariable("fullscreen",                  &fullscreen);
+    M_BindIntVariable("aspect_ratio",                &aspect_ratio);
+    M_BindIntVariable("opengles_renderer",           &opengles_renderer);
+    M_BindIntVariable("video_display",               &video_display);
+    M_BindIntVariable("vsync",                       &vsync);
+    M_BindIntVariable("show_fps",                    &show_fps);
+    M_BindIntVariable("preserve_window_aspect_ratio",&preserve_window_aspect_ratio);
+    M_BindIntVariable("smoothing",                   &smoothing);
+    M_BindIntVariable("max_fps",                     &max_fps);
+    M_BindIntVariable("vga_porch_flash",             &vga_porch_flash);
+    M_BindIntVariable("startup_delay",               &startup_delay);
+    M_BindIntVariable("resize_delay",                &resize_delay);
+    M_BindIntVariable("fullscreen_width",            &fullscreen_width);
+    M_BindIntVariable("fullscreen_height",           &fullscreen_height);
+    M_BindIntVariable("window_title_short",          &window_title_short);
+    M_BindIntVariable("window_width",                &window_width);
+    M_BindIntVariable("window_height",               &window_height);
+    M_BindIntVariable("window_border",               &window_border);
+    M_BindIntVariable("window_ontop",                &window_ontop);
+    M_BindIntVariable("grabmouse",                   &grabmouse);
+    M_BindStringVariable("video_driver",             &video_driver);
+    M_BindIntVariable("window_position_x",           &window_position_x);
+    M_BindIntVariable("window_position_y",           &window_position_y);
+    M_BindIntVariable("png_screenshots",             &png_screenshots);
 
     // Color options
     M_BindFloatVariable("brightness",              &brightness);

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -60,7 +60,7 @@ extern int actualheight;
 
 void I_DrawBlackBorders (void);
 
-// Screen height used when aspect_ratio_correct=true.
+// Screen height used when preserve_window_aspect_ratio=true.
 
 #define SCREENHEIGHT_4_3 (240 << hires)
 
@@ -136,7 +136,7 @@ extern byte *I_VideoBuffer;
 extern int screen_width;
 extern int screen_height;
 extern int fullscreen;
-extern int aspect_ratio_correct;
+extern int preserve_window_aspect_ratio;
 extern int smoothing;
 extern int vga_porch_flash;
 extern int force_software_renderer;

--- a/src/jn.h
+++ b/src/jn.h
@@ -66,7 +66,7 @@ extern int demowarp; // [JN] Demo warp from Crispy Doom.
 // -----------------------------------------------------------------------------
 
 extern int vsync;
-// extern int aspect_ratio_correct;
+// extern int preserve_window_aspect_ratio;
 extern int uncapped_fps;
 extern int show_fps, real_fps;
 extern int max_fps;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -508,7 +508,7 @@ static default_t defaults_list[] =
 
     // Rendering
     CONFIG_VARIABLE_INT(vsync),
-    CONFIG_VARIABLE_INT(aspect_ratio_correct),
+    CONFIG_VARIABLE_INT(preserve_window_aspect_ratio),
     CONFIG_VARIABLE_INT(uncapped_fps),
     CONFIG_VARIABLE_INT(show_fps),
     CONFIG_VARIABLE_INT(smoothing),

--- a/src/rd_keybinds.c
+++ b/src/rd_keybinds.c
@@ -121,6 +121,7 @@ static const char* bkToName[] = {
     "Pause",
     "Finish_demo",
     "Demo_speed",
+    "Suicide",
 
     // Toggles
     "Toggle_crosshair",
@@ -723,7 +724,7 @@ void BK_ApplyDefaultBindings()
     BK_AddBind(bk_menu_save, keyboard, SDL_SCANCODE_F2);
     BK_AddBind(bk_menu_load, keyboard, SDL_SCANCODE_F3);
     BK_AddBind(bk_menu_volume, keyboard, SDL_SCANCODE_F4);
-    BK_AddBind(bk_detail, keyboard, SDL_SCANCODE_F5);
+    BK_AddBind(bk_suicide, keyboard, SDL_SCANCODE_F5);
     BK_AddBind(bk_qsave, keyboard, SDL_SCANCODE_F6);
     BK_AddBind(bk_end_game, keyboard, SDL_SCANCODE_F7);
     BK_AddBind(bk_messages, keyboard, SDL_SCANCODE_F8);
@@ -893,7 +894,7 @@ void BK_ApplyVanilaBindings()
     BK_AddBind(bk_menu_save, keyboard, SDL_SCANCODE_F2);
     BK_AddBind(bk_menu_load, keyboard, SDL_SCANCODE_F3);
     BK_AddBind(bk_menu_volume, keyboard, SDL_SCANCODE_F4);
-    BK_AddBind(bk_detail, keyboard, SDL_SCANCODE_F5);
+    BK_AddBind(bk_suicide, keyboard, SDL_SCANCODE_F5);
     BK_AddBind(bk_qsave, keyboard, SDL_SCANCODE_F6);
     BK_AddBind(bk_end_game, keyboard, SDL_SCANCODE_F7);
     BK_AddBind(bk_messages, keyboard, SDL_SCANCODE_F8);

--- a/src/rd_keybinds.h
+++ b/src/rd_keybinds.h
@@ -113,6 +113,7 @@ typedef enum
     bk_pause,
     bk_finish_demo,
     bk_demo_speed, // [crispy] demo fast-forward
+    bk_suicide,
 
     // Toggles
     bk_toggle_crosshair,

--- a/src/rd_migration.c
+++ b/src/rd_migration.c
@@ -17,7 +17,6 @@
 
 #include <locale.h>
 #include <SDL_scancode.h>
-#include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include "d_name.h"
@@ -135,60 +134,84 @@ void M_ApplyMigration()
     if(config_version < 2)
     {
         defaultTracker_t* message_pickup_color = M_GetDefaultTracker("message_pickup_color");
-        defaultTracker_t* message_system_color = M_GetDefaultTracker("message_system_color");
-        defaultTracker_t* message_chat_color = M_GetDefaultTracker("message_chat_color");
-
-        if(message_pickup_color != NULL && message_pickup_color->found)
+        if(message_pickup_color != NULL
+        && message_pickup_color->found)
             message_color_pickup = message_pickup_color->value.i != 0 ? message_pickup_color->value.i + 1 : 0;
-        if(message_system_color != NULL && message_system_color->found)
+
+        defaultTracker_t* message_system_color = M_GetDefaultTracker("message_system_color");
+        if(message_system_color != NULL
+        && message_system_color->found)
             message_color_system = message_system_color->value.i != 0 ? message_system_color->value.i + 1 : 0;
-        if(message_chat_color != NULL && message_chat_color->found)
+
+        defaultTracker_t* message_chat_color = M_GetDefaultTracker("message_chat_color");
+        if(message_chat_color != NULL
+        && message_chat_color->found)
             message_color_chat = message_chat_color->value.i != 0 ? message_chat_color->value.i + 1 : 0;
 
-        if(RD_GameType != gt_Hexen && JN_getNotCommonIntVarPointer(v_message_color_secret) != NULL)
+        if(RD_GameType != gt_Hexen
+        && JN_getNotCommonIntVarPointer(v_message_color_secret) != NULL)
         {
             defaultTracker_t* message_secret_color = M_GetDefaultTracker("message_secret_color");
-            if(message_secret_color->found)
+            if(message_secret_color != NULL
+            && message_secret_color->found)
                 *JN_getNotCommonIntVarPointer(v_message_color_secret) = message_secret_color->value.i != 0 ? message_secret_color->value.i + 1 : 0;
         }
-        if(RD_GameType == gt_Hexen && JN_getNotCommonIntVarPointer(v_message_color_quest) != NULL)
+        if(RD_GameType == gt_Hexen
+        && JN_getNotCommonIntVarPointer(v_message_color_quest) != NULL)
         {
             defaultTracker_t* message_quest_color = M_GetDefaultTracker("message_quest_color");
-            if(message_quest_color->found)
+            if(message_quest_color != NULL
+            && message_quest_color->found)
                 *JN_getNotCommonIntVarPointer(v_message_color_quest) = message_quest_color->value.i != 0 ? message_quest_color->value.i + 1 : 0;
         }
 
         if(RD_GameType == gt_Doom)
         {
             defaultTracker_t* sbar_color_high = M_GetDefaultTracker("sbar_color_high");
-            defaultTracker_t* sbar_color_normal = M_GetDefaultTracker("sbar_color_normal");
-            defaultTracker_t* sbar_color_low = M_GetDefaultTracker("sbar_color_low");
-            defaultTracker_t* sbar_color_critical = M_GetDefaultTracker("sbar_color_critical");
-            defaultTracker_t* sbar_color_armor_1 = M_GetDefaultTracker("sbar_color_armor_1");
-            defaultTracker_t* sbar_color_armor_2 = M_GetDefaultTracker("sbar_color_armor_2");
-            defaultTracker_t* sbar_color_armor_0 = M_GetDefaultTracker("sbar_color_armor_0");
-
-            if(JN_getNotCommonIntVarPointer(v_stbar_color_high) != NULL && sbar_color_high->found)
+            if(sbar_color_high != NULL
+            && sbar_color_high->found
+            && JN_getNotCommonIntVarPointer(v_stbar_color_high) != NULL)
                 *JN_getNotCommonIntVarPointer(v_stbar_color_high) = sbar_color_high->value.i + 1;
-            if(JN_getNotCommonIntVarPointer(v_stbar_color_normal) != NULL && sbar_color_normal->found)
+
+            defaultTracker_t* sbar_color_normal = M_GetDefaultTracker("sbar_color_normal");
+            if(sbar_color_normal != NULL
+            && sbar_color_normal->found
+            && JN_getNotCommonIntVarPointer(v_stbar_color_normal) != NULL)
                 *JN_getNotCommonIntVarPointer(v_stbar_color_normal) = sbar_color_normal->value.i + 1;
-            if(JN_getNotCommonIntVarPointer(v_stbar_color_low) != NULL && sbar_color_low->found)
+
+            defaultTracker_t* sbar_color_low = M_GetDefaultTracker("sbar_color_low");
+            if(sbar_color_low != NULL
+            && sbar_color_low->found
+            && JN_getNotCommonIntVarPointer(v_stbar_color_low) != NULL)
                 *JN_getNotCommonIntVarPointer(v_stbar_color_low) = sbar_color_low->value.i + 1;
-            if(JN_getNotCommonIntVarPointer(v_stbar_color_critical) != NULL && sbar_color_critical->found)
+
+            defaultTracker_t* sbar_color_critical = M_GetDefaultTracker("sbar_color_critical");
+            if(sbar_color_critical != NULL
+            && sbar_color_critical->found
+            && JN_getNotCommonIntVarPointer(v_stbar_color_critical) != NULL)
                 *JN_getNotCommonIntVarPointer(v_stbar_color_critical) = sbar_color_critical->value.i + 1;
-            if(JN_getNotCommonIntVarPointer(v_stbar_color_armor_1) != NULL && sbar_color_armor_1->found)
+
+            defaultTracker_t* sbar_color_armor_1 = M_GetDefaultTracker("sbar_color_armor_1");
+            if(sbar_color_armor_1 != NULL
+            && sbar_color_armor_1->found
+            && JN_getNotCommonIntVarPointer(v_stbar_color_armor_1) != NULL)
                 *JN_getNotCommonIntVarPointer(v_stbar_color_armor_1) = sbar_color_armor_1->value.i + 1;
-            if(JN_getNotCommonIntVarPointer(v_stbar_color_armor_2) != NULL && sbar_color_armor_2->found)
+
+            defaultTracker_t* sbar_color_armor_2 = M_GetDefaultTracker("sbar_color_armor_2");
+            if(sbar_color_armor_2 != NULL
+            && sbar_color_armor_2->found
+            && JN_getNotCommonIntVarPointer(v_stbar_color_armor_2) != NULL)
                 *JN_getNotCommonIntVarPointer(v_stbar_color_armor_2) = sbar_color_armor_2->value.i + 1;
-            if(JN_getNotCommonIntVarPointer(v_stbar_color_armor_0) != NULL && sbar_color_armor_0->found)
+
+            defaultTracker_t* sbar_color_armor_0 = M_GetDefaultTracker("sbar_color_armor_0");
+            if(sbar_color_armor_0 != NULL
+            && sbar_color_armor_0->found
+            && JN_getNotCommonIntVarPointer(v_stbar_color_armor_0) != NULL)
                 *JN_getNotCommonIntVarPointer(v_stbar_color_armor_0) = sbar_color_armor_0->value.i + 1;
         }
 
         // Reread binds for bk_map_rotate, bk_map_rotate and bk_forward to prioritize them over multiplayer chat keys
         keybindsTracker_t* Map_rotate_tracker = M_GetKeybindsTracker("Map_rotate");
-        keybindsTracker_t* Map_Grid_tracker = M_GetKeybindsTracker("Map_grid");
-        keybindsTracker_t* Forward_tracker = M_GetKeybindsTracker("Forward");
-
         if(Map_rotate_tracker != NULL
         && !IsBindingsEqual(
             &Map_rotate_tracker->descriptors,
@@ -202,6 +225,7 @@ void M_ApplyMigration()
             SetKeyBindingsToTracked(bk_map_rotate, Map_rotate_tracker);
         }
 
+        keybindsTracker_t* Map_Grid_tracker = M_GetKeybindsTracker("Map_grid");
         if(Map_Grid_tracker != NULL
         && !IsBindingsEqual(
             &Map_Grid_tracker->descriptors,
@@ -214,6 +238,7 @@ void M_ApplyMigration()
             SetKeyBindingsToTracked(bk_map_grid, Map_Grid_tracker);
         }
 
+        keybindsTracker_t* Forward_tracker = M_GetKeybindsTracker("Forward");
         if(RD_GameType == gt_Hexen
         && Forward_tracker != NULL
         && !IsBindingsEqual(

--- a/src/rd_migration.c
+++ b/src/rd_migration.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include "d_name.h"
+#include "i_video.h"
 #include "jn.h"
 #include "m_misc.h"
 #include "rd_keybinds.h"
@@ -71,6 +72,29 @@ void M_RegisterTrackedFields()
         RegisterTrackedKeybind("Map_grid");
         if(RD_GameType == gt_Hexen)
             RegisterTrackedKeybind("Forward");
+    }
+
+    //
+    // Changed name of "aspect_ratio_correct" config entry to "preserve_window_aspect_ratio".
+    // Changed names of some of "automap_*" and "hud_*" config entries to "stats_*".
+    // Separated bindings for "Suicide" and "Detail level" in Hexen.
+    //
+    if(config_version < 3)
+    {
+        RegisterTrackedDefault("aspect_ratio_correct", DEFAULT_INT);
+
+        RegisterTrackedDefault("automap_stats", DEFAULT_INT);
+        RegisterTrackedDefault("automap_skill", DEFAULT_INT);
+        RegisterTrackedDefault("automap_level_time", DEFAULT_INT);
+        RegisterTrackedDefault("automap_total_time", DEFAULT_INT);
+        RegisterTrackedDefault("automap_coords", DEFAULT_INT);
+        RegisterTrackedDefault("hud_stats_color", DEFAULT_INT);
+
+        if(RD_GameType == gt_Doom)
+            RegisterTrackedDefault("hud_level_name", DEFAULT_INT);
+
+        if(RD_GameType == gt_Hexen)
+            RegisterTrackedKeybind("Detail");
     }
 }
 
@@ -198,6 +222,67 @@ void M_ApplyMigration()
         && IsBindingsListContains(&bind_descriptor[bk_multi_msg_player_5], keyboard, SDL_SCANCODE_W))
         {
             SetKeyBindingsToTracked(bk_forward, Forward_tracker);
+        }
+    }
+
+    //
+    // Changed name of "aspect_ratio_correct" config entry to "preserve_window_aspect_ratio".
+    // Changed names of some of "automap_*" and "hud_*" config entries to "stats_*".
+    // Separated bindings for "Suicide" and "Detail level" in Hexen.
+    //
+    if(config_version < 3)
+    {
+        defaultTracker_t* aspect_ratio_correct = M_GetDefaultTracker("aspect_ratio_correct");
+        if(aspect_ratio_correct != NULL
+        && aspect_ratio_correct->found)
+            preserve_window_aspect_ratio = aspect_ratio_correct->value.i;
+
+        defaultTracker_t* automap_stats = M_GetDefaultTracker("automap_stats");
+        if(automap_stats != NULL
+        && automap_stats->found)
+            stats_kis = automap_stats->value.i;
+
+        defaultTracker_t* automap_skill = M_GetDefaultTracker("automap_skill");
+        if(automap_skill != NULL
+        && automap_skill->found)
+            stats_skill = automap_skill->value.i;
+
+        defaultTracker_t* automap_level_time = M_GetDefaultTracker("automap_level_time");
+        if(automap_level_time != NULL
+        && automap_level_time->found)
+            stats_level_time = automap_level_time->value.i;
+
+        defaultTracker_t* automap_total_time = M_GetDefaultTracker("automap_total_time");
+        if(automap_total_time != NULL
+        && automap_total_time->found)
+            stats_total_time = automap_total_time->value.i;
+
+        defaultTracker_t* automap_coords = M_GetDefaultTracker("automap_coords");
+        if(automap_coords != NULL
+        && automap_coords->found)
+            stats_coords = automap_coords->value.i;
+
+        defaultTracker_t* hud_stats_color = M_GetDefaultTracker("hud_stats_color");
+        if(hud_stats_color != NULL
+        && hud_stats_color->found)
+            stats_color = hud_stats_color->value.i;
+
+        if(RD_GameType == gt_Doom)
+        {
+            defaultTracker_t* hud_level_name = M_GetDefaultTracker("hud_level_name");
+            if(hud_level_name != NULL
+            && hud_level_name->found)
+                stats_level_name = hud_level_name->value.i;
+        }
+
+        if(RD_GameType == gt_Hexen)
+        {
+            keybindsTracker_t* Detail_tracker = M_GetKeybindsTracker("Detail");
+            if(Detail_tracker != NULL)
+            {
+                BK_ClearBinds(bk_detail);
+                SetKeyBindingsToTracked(bk_suicide, Detail_tracker);
+            }
         }
     }
 

--- a/src/rd_migration.h
+++ b/src/rd_migration.h
@@ -30,8 +30,11 @@ enum {
     *     Changed text representation of NumPad 'Del' key from 'KP_,' to 'KP_.'.\n
     * 2 - Changed names of 'message_*_color' and 'sbar_color_*' config entries.
     *     Fixed broken bk_map_rotate, bk_map_rotate and bk_forward.\n
+    * 3 - Changed name of "aspect_ratio_correct" config entry to "preserve_window_aspect_ratio".
+    *     Changed names of some of "automap_*" and "hud_*" config entries to "stats_*".
+    *     Separated bindings for "Suicide" and "Detail level" in Hexen.\n
     */
-    CURRENT_CONFIG_VERSION = 2
+    CURRENT_CONFIG_VERSION = 3
 };
 
 /**

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -1442,7 +1442,7 @@ void V_Init (void)
 
     screenwidth_low = screenwidth << hires;
 
-    if (aspect_ratio_correct)
+    if (preserve_window_aspect_ratio)
     {
         if (aspect_ratio == 1)
         actualheight = SCREENHEIGHT_5_4;


### PR DESCRIPTION
Resolves #368

* Hexen: Added separate bind `bk_suicide` for "Suicide" and add proper implementation for `bk_detail`.
* Rename `aspect_ratio_correct` config entry to `preserve_window_aspect_ratio`.
* Add migration rules for changed config entries.