### PR TITLE
Make visplane variables strictly local

### DIFF
--- a/src/doom/r_local.h
+++ b/src/doom/r_local.h
@@ -516,10 +516,6 @@ extern fixed_t     dc_texturemid;
 extern const byte *dc_translation;
 extern byte       *translationtables;
 
-extern fixed_t ds_y, ds_x1, ds_x2;
-extern fixed_t ds_xfrac, ds_yfrac;
-extern fixed_t ds_xstep, ds_ystep;
-
 extern const lighttable_t *ds_colormap[2];
 extern const byte         *ds_source;
 extern const byte         *ds_brightmap;
@@ -538,8 +534,12 @@ void R_DrawFuzzColumnTranslucent (void);
 void R_DrawFuzzColumnTranslucentLow (void);
 void R_DrawGhostColumn (void);
 void R_DrawGhostColumnLow (void);
-void R_DrawSpan (void);
-void R_DrawSpanLow (void);
+void R_DrawSpan (fixed_t x1, fixed_t x2, const fixed_t y,
+                 fixed_t ds_xfrac, const fixed_t ds_xstep,
+                 fixed_t ds_yfrac, const fixed_t ds_ystep);
+void R_DrawSpanLow (fixed_t x1, fixed_t x2, const fixed_t y,
+                    fixed_t ds_xfrac, const fixed_t ds_xstep,
+                    fixed_t ds_yfrac, const fixed_t ds_ystep);
 void R_DrawTLColumn (void);
 void R_DrawTLColumnLow (void);
 void R_DrawTranslatedColumn (void);
@@ -595,11 +595,13 @@ extern lighttable_t *zlight[LIGHTLEVELS][MAXLIGHTZ];
 extern void (*basecolfunc) (void);
 extern void (*colfunc) (void);
 extern void (*fuzzcolfunc) (void);
-extern void (*spanfunc) (void);
 extern void (*tlcolfunc) (void);
 extern void (*transcolfunc) (void);
 extern void (*transtlcolfunc) (void);
 extern void (*ghostcolfunc) (void);
+extern void (*spanfunc) (fixed_t x1, fixed_t x2, fixed_t y,
+                         fixed_t ds_xfrac, const fixed_t ds_xstep,
+                         fixed_t ds_yfrac, const fixed_t ds_ystep);
 extern void R_InitLightTables (void);
 extern void R_ClearStats (void);
 

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -100,7 +100,9 @@ void (*transcolfunc) (void);
 void (*tlcolfunc) (void);
 void (*transtlcolfunc) (void);
 void (*ghostcolfunc) (void);
-void (*spanfunc) (void);
+void (*spanfunc) (fixed_t x1, fixed_t x2, fixed_t const y,
+                  fixed_t ds_xfrac, const fixed_t ds_xstep,
+                  fixed_t ds_yfrac, const fixed_t ds_ystep);
 
 
 // -----------------------------------------------------------------------------

--- a/src/doom/r_plane.c
+++ b/src/doom/r_plane.c
@@ -159,6 +159,8 @@ static void R_MapPlane (const int y, const int x1, const int x2)
     unsigned index;
     int      dx, dy;
     fixed_t	 distance;
+    fixed_t	 ds_xfrac, ds_yfrac;
+    fixed_t	 ds_xstep, ds_ystep;
 
 #ifdef RANGECHECK
     if (x2 < x1 || x1 < 0 || x2 >= viewwidth || y > viewheight)
@@ -212,12 +214,8 @@ static void R_MapPlane (const int y, const int x1, const int x2)
         ds_colormap[1] = colormaps;
     }
 
-    ds_y = y;
-    ds_x1 = x1;
-    ds_x2 = x2;
-
     // high or low detail
-    spanfunc ();	
+    spanfunc (x1, x2, y, ds_xfrac, ds_xstep, ds_yfrac, ds_ystep);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -956,20 +956,22 @@ void R_DrawTranslatedTLColumnLow (void)
 ================================================================================
 */
 
-void R_DrawSpan (void)
+void R_DrawSpan (fixed_t x1, fixed_t x2, const fixed_t y,
+                 fixed_t ds_xfrac, const fixed_t ds_xstep,
+                 fixed_t ds_yfrac, const fixed_t ds_ystep)
 {
-    unsigned int count = ds_x2 - ds_x1;  // We do not check for zero spans here.
+    unsigned int count = x2 - x1;  // We do not check for zero spans here.
     const byte  *source = ds_source;
     const byte  *brightmap = ds_brightmap;
     const byte **colormap = ds_colormap;
 
 #ifdef RANGECHECK
-    if (ds_x2 < ds_x1 || ds_x1 < 0 || ds_x2 >= screenwidth
-        || (unsigned) ds_y > SCREENHEIGHT)
+    if (x2 < x1 || x1 < 0 || x2 >= screenwidth
+        || (unsigned) y > SCREENHEIGHT)
         I_Error(english_language ?
                 "R_DrawSpan: %i to %i at %i" :
                 "R_DrawSpan: %i к %i в %i",
-                ds_x1, ds_x2, ds_y);
+                x1, x2, y);
 #endif
 
     // Pack position and step variables into a single 32-bit integer,
@@ -980,13 +982,11 @@ void R_DrawSpan (void)
 
     do
     {
-        byte *dest = ylookup[ds_y] + columnofs[flipviewwidth[ds_x1++]];
+        byte *dest = ylookup[y] + columnofs[flipviewwidth[x1++]];
 
         // Calculate current texture index in u,v.
         // [crispy] fix flats getting more distorted the closer they are to the right
-        unsigned const int ytemp = (ds_yfrac >> 10) & 0x0fc0;
-        unsigned const int xtemp = (ds_xfrac >> 16) & 0x3f;
-        unsigned const int spot = xtemp | ytemp;
+        unsigned const int spot = ((ds_xfrac >> 16) & 0x3f) | ((ds_yfrac >> 10) & 0x0fc0);
 
         // Lookup pixel from flat texture tile, re-index using light/colormap.
         *dest = colormap[brightmap[source[spot]]][source[spot]];
@@ -1006,28 +1006,30 @@ void R_DrawSpan (void)
 ================================================================================
 */
 
-void R_DrawSpanLow (void)
+void R_DrawSpanLow (fixed_t x1, fixed_t x2, const fixed_t y,
+                    fixed_t ds_xfrac, const fixed_t ds_xstep,
+                    fixed_t ds_yfrac, const fixed_t ds_ystep)
 {
-    unsigned int count = ds_x2 - ds_x1;  // We do not check for zero spans here.
-    const int    ds_y_low = ds_y << hires;
+    unsigned int count = x2 - x1;  // We do not check for zero spans here.
+    const int    ds_y_low = y << hires;
     const byte  *source = ds_source;
     const byte  *brightmap = ds_brightmap;
     const byte **colormap = ds_colormap;
     byte        *dest1, *dest2;
 
 #ifdef RANGECHECK
-    if (ds_x2 < ds_x1 || ds_x1<0 || ds_x2>=screenwidth || (unsigned)ds_y>SCREENHEIGHT)
+    if (x2 < x1 || x1 < 0 || x2 >= screenwidth || (unsigned)y > SCREENHEIGHT)
     {
         I_Error(english_language ?
                 "R_DrawSpan: %i to %i at %i" :
                 "R_DrawSpan: %i к %i у %i",
-                ds_x1,ds_x2,ds_y);
+                x1, x2, y);
     }
 #endif
 
     // Blocky mode, need to multiply by 2.
-    ds_x1 <<= 1;
-    ds_x2 <<= 1;
+    x1 <<= 1;
+    x2 <<= 1;
 
     // Pack position and step variables into a single 32-bit integer,
     // with x in the top 16 bits and y in the bottom 16 bits.  For
@@ -1038,18 +1040,16 @@ void R_DrawSpanLow (void)
     {
         // Calculate current texture index in u,v.
         // [crispy] fix flats getting more distorted the closer they are to the right
-        unsigned const int ytemp = (ds_yfrac >> 10) & 0x0fc0;
-        unsigned const int xtemp = (ds_xfrac >> 16) & 0x3f;
-        unsigned const int spot = xtemp | ytemp;
+        unsigned const int spot = ((ds_xfrac >> 16) & 0x3f) | ((ds_yfrac >> 10) & 0x0fc0);
 
         // Lowres/blocky mode does it twice, while scale is adjusted appropriately.
-         dest1 = ylookup[ds_y_low] + columnofs[flipviewwidth[ds_x1]];
+         dest1 = ylookup[ds_y_low] + columnofs[flipviewwidth[x1]];
         *dest1 = colormap[brightmap[source[spot]]][source[spot]];
-         dest2 = ylookup[ds_y_low + 1] + columnofs[flipviewwidth[ds_x1++]];
+         dest2 = ylookup[ds_y_low + 1] + columnofs[flipviewwidth[x1++]];
         *dest2 = colormap[brightmap[source[spot]]][source[spot]];
-         dest1 = ylookup[ds_y_low] + columnofs[flipviewwidth[ds_x1]];
+         dest1 = ylookup[ds_y_low] + columnofs[flipviewwidth[x1]];
         *dest1 = colormap[brightmap[source[spot]]][source[spot]];
-         dest2 = ylookup[ds_y_low + 1] + columnofs[flipviewwidth[ds_x1++]];
+         dest2 = ylookup[ds_y_low + 1] + columnofs[flipviewwidth[x1++]];
         *dest2 = colormap[brightmap[source[spot]]][source[spot]];
 
         // position += step;

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -394,18 +394,10 @@ extern fixed_t dc_texturemid;
 extern fixed_t dc_x;
 extern fixed_t dc_yh;
 extern fixed_t dc_yl;
-extern fixed_t ds_xfrac;
-extern fixed_t ds_xstep;
-extern fixed_t ds_yfrac;
-extern fixed_t ds_ystep;
 extern fixed_t skyiscale;
 extern fixed_t skyiscale_low;
 extern fixed_t skytextureheight;
-
-extern int ds_x1;
-extern int ds_x2;
-extern int ds_y;
-extern int skytexturemid;
+extern int     skytexturemid;
 
 extern void R_DrawColumn (void);
 extern void R_DrawColumnLow (void);
@@ -413,14 +405,18 @@ extern void R_DrawExtraTLColumn (void);
 extern void R_DrawExtraTLColumnLow (void);
 extern void R_DrawSkyColumn (void);
 extern void R_DrawSkyColumnLow (void);
-extern void R_DrawSpan (void);
-extern void R_DrawSpanLow (void);
 extern void R_DrawTLColumn (void);
 extern void R_DrawTLColumnLow (void);
 extern void R_DrawTranslatedColumn (void);
 extern void R_DrawTranslatedColumnLow (void);
 extern void R_DrawTranslatedTLColumn (void);
 extern void R_DrawTranslatedTLColumnLow (void);
+extern void R_DrawSpan (fixed_t x1, fixed_t x2, const fixed_t y,
+                        fixed_t ds_xfrac, const fixed_t ds_xstep,
+                        fixed_t ds_yfrac, const fixed_t ds_ystep);
+extern void R_DrawSpanLow (fixed_t x1, fixed_t x2, const fixed_t y,
+                           fixed_t ds_xfrac, const fixed_t ds_xstep,
+                           fixed_t ds_yfrac, const fixed_t ds_ystep);
 extern void R_InitBuffer (const int width, const int height);
 
 /*
@@ -505,10 +501,12 @@ extern void (*basecolfunc) (void);
 extern void (*colfunc) (void);
 extern void (*extratlcolfunc) (void);
 extern void (*skycolfunc) (void);
-extern void (*spanfunc) (void);
 extern void (*tlcolfunc) (void);
 extern void (*transcolfunc) (void);
 extern void (*transtlcolfunc) (void);
+extern void (*spanfunc) (fixed_t x1, fixed_t x2, const fixed_t y,
+                         fixed_t ds_xfrac, const fixed_t ds_xstep,
+                         fixed_t ds_yfrac, const fixed_t ds_ystep);
 
 extern void R_ClearStats (void); // [JN] Used by perfomance counter.
 extern void R_DrawTopBorder (void);

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -84,7 +84,9 @@ void (*tlcolfunc) (void);
 void (*extratlcolfunc) (void);
 void (*transcolfunc) (void);
 void (*transtlcolfunc) (void);
-void (*spanfunc) (void);
+void (*spanfunc) (fixed_t x1, fixed_t x2, const fixed_t y,
+                  fixed_t ds_xfrac, const fixed_t ds_xstep,
+                  fixed_t ds_yfrac, const fixed_t ds_ystep);
 
 
 /*

--- a/src/heretic/r_plane.c
+++ b/src/heretic/r_plane.c
@@ -212,6 +212,8 @@ static void R_MapPlane (const int y, const int x1, const int x2)
     unsigned  index;
     int       dx, dy;
     fixed_t   distance;
+    fixed_t   ds_xfrac, ds_yfrac;
+    fixed_t   ds_xstep, ds_ystep;
 
 #ifdef RANGECHECK
     if (x2 < x1 || x1 < 0 || x2 >= viewwidth || (unsigned) y > viewheight)
@@ -266,12 +268,8 @@ static void R_MapPlane (const int y, const int x1, const int x2)
         ds_colormap[1] = colormaps;
     }
 
-    ds_y = y;
-    ds_x1 = x1;
-    ds_x2 = x2;
-
     // High or low detail
-    spanfunc();
+    spanfunc(x1, x2, y, ds_xfrac, ds_xstep, ds_yfrac, ds_ystep);
 }
 
 /*

--- a/src/hexen/r_draw.c
+++ b/src/hexen/r_draw.c
@@ -1005,19 +1005,21 @@ void R_InitTranslationTables(void)
 ================================================================================
 */
 
-void R_DrawSpan (void)
+void R_DrawSpan (fixed_t x1, fixed_t x2, const fixed_t y,
+                 fixed_t ds_xfrac, const fixed_t ds_xstep,
+                 fixed_t ds_yfrac, const fixed_t ds_ystep)
 {
-    unsigned int count = ds_x2 - ds_x1;  // We do not check for zero spans here.
+    unsigned int count = x2 - x1;  // We do not check for zero spans here.
     const byte  *source = ds_source;
     const byte  *colormap = ds_colormap;
 
 #ifdef RANGECHECK
-    if (ds_x2 < ds_x1 || ds_x1 < 0 || ds_x2 >= screenwidth
-        || (unsigned) ds_y > SCREENHEIGHT)
+    if (x2 < x1 || x1 < 0 || x2 >= screenwidth
+        || (unsigned)y > SCREENHEIGHT)
         I_Error(english_language ?
                 "R_DrawSpan: %i to %i at %i" :
                 "R_DrawSpan: %i к %i в %i",
-                ds_x1, ds_x2, ds_y);
+                x1, x2, y);
 #endif
 
     // Pack position and step variables into a single 32-bit integer,
@@ -1028,13 +1030,11 @@ void R_DrawSpan (void)
 
     do
     {
-        byte *dest = ylookup[ds_y] + columnofs[flipviewwidth[ds_x1++]];
+        byte *dest = ylookup[y] + columnofs[flipviewwidth[x1++]];
 
         // Calculate current texture index in u,v.
         // [crispy] fix flats getting more distorted the closer they are to the right
-        unsigned const int ytemp = (ds_yfrac >> 10) & 0x0fc0;
-        unsigned const int xtemp = (ds_xfrac >> 16) & 0x3f;
-        unsigned const int spot = xtemp | ytemp;
+        unsigned const int spot = ((ds_xfrac >> 16) & 0x3f) | ((ds_yfrac >> 10) & 0x0fc0);
 
         // Lookup pixel from flat texture tile, re-index using light/colormap.
         *dest = colormap[source[spot]];
@@ -1054,16 +1054,16 @@ void R_DrawSpan (void)
 ================================================================================
 */
 
-void R_DrawSpanLow(void)
+void R_DrawSpanLow (fixed_t x1, fixed_t x2, const fixed_t y,
+                    fixed_t ds_xfrac, const fixed_t ds_xstep,
+                    fixed_t ds_yfrac, const fixed_t ds_ystep)
 {
-    byte    *dest, *dest2;
-    int      count = (ds_x2 - ds_x1);
-    int      spot;
-    unsigned int xtemp, ytemp;
+    unsigned int count = x2 - x1;  // We do not check for zero spans here.
+    const int  ds_y_low = y << hires;
+    byte      *dest, *dest2;
 
 #ifdef RANGECHECK
-    if (ds_x2 < ds_x1 || ds_x1 < 0
-	||  ds_x2 >= screenwidth || (unsigned)ds_y > SCREENHEIGHT)
+    if (x2 < x1 || x1<0 || x2>=screenwidth || (unsigned)y>SCREENHEIGHT)
     {
         I_Error(english_language ?
                 "R_DrawSpan: %i to %i at %i" :
@@ -1073,25 +1073,23 @@ void R_DrawSpanLow(void)
 #endif
 
     // Blocky mode, need to multiply by 2.
-    ds_x1 <<= 1;
-    ds_x2 <<= 1;
+    x1 <<= 1;
+    x2 <<= 1;
 
     do
     {
         // Calculate current texture index in u,v.
         // [crispy] fix flats getting more distorted the closer they are to the right
-        ytemp = (ds_yfrac >> 10) & 0x0fc0;
-        xtemp = (ds_xfrac >> 16) & 0x3f;
-        spot = xtemp | ytemp;
+        unsigned const int spot = ((ds_xfrac >> 16) & 0x3f) | ((ds_yfrac >> 10) & 0x0fc0);
 
         // Lowres/blocky mode does it twice, while scale is adjusted appropriately.
-        dest = ylookup[(ds_y << hires)] + columnofs[flipviewwidth[ds_x1]];
+        dest = ylookup[ds_y_low] + columnofs[flipviewwidth[x1]];
         *dest = ds_colormap[ds_source[spot]];
-        dest2 = ylookup[(ds_y << hires) + 1] + columnofs[flipviewwidth[ds_x1++]];
+        dest2 = ylookup[ds_y_low + 1] + columnofs[flipviewwidth[x1++]];
         *dest2 = ds_colormap[ds_source[spot]];
-        dest = ylookup[(ds_y << hires)] + columnofs[flipviewwidth[ds_x1]];
+        dest = ylookup[ds_y_low] + columnofs[flipviewwidth[x1]];
         *dest = ds_colormap[ds_source[spot]];
-        dest2 = ylookup[(ds_y << hires) + 1] + columnofs[flipviewwidth[ds_x1++]];
+        dest2 = ylookup[ds_y_low + 1] + columnofs[flipviewwidth[x1++]];
         *dest2 = ds_colormap[ds_source[spot]];
 
         // position += step;

--- a/src/hexen/r_local.h
+++ b/src/hexen/r_local.h
@@ -400,7 +400,9 @@ extern void (*alttlcolfunc) (void);
 extern void (*extratlcolfunc) (void);
 extern void (*transcolfunc) (void);
 extern void (*transtlcolfunc) (void);
-extern void (*spanfunc) (void);
+extern void (*spanfunc) (fixed_t x1, fixed_t x2, const fixed_t y,
+                         fixed_t ds_xfrac, const fixed_t ds_xstep,
+                         fixed_t ds_yfrac, const fixed_t ds_ystep);
 extern void R_ExecuteSetViewSize();
 extern void R_InitLightTables (void);
 
@@ -573,22 +575,19 @@ void R_DrawTranslatedTLColumn(void);
 void R_DrawTranslatedTLColumnLow(void);
 
 
-extern int ds_y;
-extern int ds_x1;
-extern int ds_x2;
 extern const lighttable_t *ds_colormap;
-extern fixed_t ds_xfrac;
-extern fixed_t ds_yfrac;
-extern fixed_t ds_xstep;
-extern fixed_t ds_ystep;
 extern byte *ds_source;         // start of a 64*64 tile image
 extern const byte *ds_brightmap;
 
 extern byte *translationtables;
 extern byte *dc_translation;
 
-void R_DrawSpan(void);
-void R_DrawSpanLow(void);
+void R_DrawSpan(fixed_t x1, fixed_t x2, const fixed_t y,
+                fixed_t ds_xfrac, const fixed_t ds_xstep,
+                fixed_t ds_yfrac, const fixed_t ds_ystep);
+void R_DrawSpanLow(fixed_t x1, fixed_t x2, const fixed_t y,
+                   fixed_t ds_xfrac, const fixed_t ds_xstep,
+                   fixed_t ds_yfrac, const fixed_t ds_ystep);
 
 void R_InitBuffer(int width, int height);
 void R_InitTranslationTables(void);

--- a/src/hexen/r_main.c
+++ b/src/hexen/r_main.c
@@ -90,7 +90,9 @@ void (*alttlcolfunc) (void);
 void (*extratlcolfunc) (void);
 void (*transcolfunc) (void);
 void (*transtlcolfunc) (void);
-void (*spanfunc) (void);
+void (*spanfunc) (fixed_t x1, fixed_t x2, const fixed_t y,
+                  fixed_t ds_xfrac, const fixed_t ds_xstep,
+                  fixed_t ds_yfrac, const fixed_t ds_ystep);
 
 /*
 ================================================================================

--- a/src/hexen/r_plane.c
+++ b/src/hexen/r_plane.c
@@ -223,9 +223,11 @@ void R_InitSkyMap (void)
 
 void R_MapPlane (int y, int x1, int x2)
 {
-    fixed_t   distance;
     unsigned  index;
     int       dx, dy;
+    fixed_t   distance;
+    fixed_t   ds_xfrac, ds_yfrac;
+    fixed_t   ds_xstep, ds_ystep;
 
 #ifdef RANGECHECK
     if (x2 < x1 || x1 < 0 || x2 >= viewwidth || (unsigned) y > viewheight)
@@ -279,12 +281,8 @@ void R_MapPlane (int y, int x1, int x2)
         ds_colormap = planezlight[index];
     }
 
-    ds_y = y;
-    ds_x1 = x1;
-    ds_x2 = x2;
-
     // High or low detail
-    spanfunc();
+    spanfunc(x1, x2, y, ds_xfrac, ds_xstep, ds_yfrac, ds_ystep);
 }
 
 /*


### PR DESCRIPTION
The idea is to get rid of global variables to let `R_DrawSpan(Low)` use pre-given values instead of gathering them from outside.

According to my benchmarks, this micro-optimization makes visplane drawing slightly faster on both extreme scenes (~+1-2 fps, [testing level](https://objects.githubusercontent.com/github-production-repository-file-5c1aeb/83121322/6450990?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230119%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230119T065943Z&X-Amz-Expires=300&X-Amz-Signature=25d1a5acda4dccde87805b9f7373d084d965464f56e59e635dc75cbc72f6713e&X-Amz-SignedHeaders=host&actor_id=21193394&key_id=0&repo_id=83121322&response-content-disposition=attachment%3Bfilename%3Dpitto.zip&response-content-type=application%2Fx-zip-compressed)) and timedemo runs. Same potential probably lies in column drawing functions as well.