### PR TITLE
Fix problems with vertical look in Heretic

### DIFF
--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -560,18 +560,22 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
     {
         if (demorecording || lowres_turn)
         {
-            // [crispy] Map mouse movement to look variable when recording
-            look += mouse_y_invert ? -mousey / MLOOKUNITLOWRES
-                                   :  mousey / MLOOKUNITLOWRES;
+            // [Dasperal] Skip mouse look if it is TOCENTER cmd
+            if(look != TOCENTER)
+            {
+                // [crispy] Map mouse movement to look variable when recording
+                look += mouse_y_invert ? -mousey / MLOOKUNITLOWRES
+                                       :  mousey / MLOOKUNITLOWRES;
 
-            // [crispy] Limit to max speed of keyboard look up/down
-            if (look > 2)
-            {
-                look = 2;
-            }
-            else if (look < -2)
-            {
-                look = -2;
+                // [crispy] Limit to max speed of keyboard look up/down
+                if(look > 2)
+                {
+                    look = 2;
+                }
+                else if(look < -2)
+                {
+                    look = -2;
+                }
             }
         }
         else

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -567,6 +567,9 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
                 look += mouse_y_invert ? -mousey / MLOOKUNITLOWRES
                                        :  mousey / MLOOKUNITLOWRES;
 
+                // [Dasperal] Vertical look with gamepad
+                look += FixedMul(angleturn[2], joyvlook) / MLOOKUNITLOWRES;
+
                 // [crispy] Limit to max speed of keyboard look up/down
                 if(look > 2)
                 {
@@ -581,12 +584,14 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         else
         {
             cmd->lookdir = mouse_y_invert ? -mousey : mousey;
+            cmd->lookdir += FixedMul(angleturn[2], joyvlook);
             cmd->lookdir /= MLOOKUNIT;
         }
     }
     else if (!novert)
     {
         forward += mousey;
+        forward += FixedMul(forwardmove[speed], joyvlook);
     }
 
     // [JN] Toggle mouselook

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -585,7 +585,11 @@ void G_BuildTiccmd(ticcmd_t *cmd, int maketic)
         {
             cmd->lookdir = mouse_y_invert ? -mousey : mousey;
             cmd->lookdir += FixedMul(angleturn[2], joyvlook);
-            cmd->lookdir /= MLOOKUNIT;
+            // [Dasperal] Allow precise vertical look with near 0 mouse/gamepad movement
+            if(cmd->lookdir > 0)
+                cmd->lookdir = (cmd->lookdir + MLOOKUNIT - 1) / MLOOKUNIT;
+            else
+                cmd->lookdir = (cmd->lookdir - MLOOKUNIT + 1) / MLOOKUNIT;
         }
     }
     else if (!novert)


### PR DESCRIPTION
* Fixes `bk_look_center` not working properly while recording a demo
* Fixes #427
* Fixes the problem when the slightest vertical movement of the mouse doesn't affect vertical look. [Hanomamoru](https://www.twitch.tv/hanomamoru) complained about this on his streams. I found the same problem with horizontal mouse movement to the left while recording a demo, but couldn't track down the source.

I don't think those changes can break demo compatibility, but testing is required. @JNechaevsky 