### PR TITLE
CI: Binary cashing for VCPKG using NuGet

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -143,7 +143,7 @@ jobs:
           if [[ '${{ matrix.compiler.display_name }}' == 'MSVC' ]]
           then
               msvc_gen_opts='${{ matrix.arch.msvc_gen_opts }}'
-              msvc_cmake_toolchain='-D CMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake'
+              msvc_cmake_toolchain="-D CMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
           fi
           if [[ '${{ matrix.os.name }}' == 'Linux' ]]
           then

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,6 +82,10 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.shell }}
+    env:
+      VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
+    permissions:
+      packages: write # For VCPKG binary caching wint NuGet
     steps:
       - name: Setup MSYS env
         if: |
@@ -118,8 +122,22 @@ jobs:
                   --nocache --norestart --quiet
               echo "Installation of Microsoft.VisualStudio.Component.WinXP finished"
           fi
-          cd $VCPKG_INSTALLATION_ROOT && git pull
+          cd $VCPKG_INSTALLATION_ROOT
+          git pull
+          ./bootstrap-vcpkg.sh -disableMetrics
+          nuget=$(./vcpkg.exe fetch nuget | tail -n 1)
+          owner="${GITHUB_REPOSITORY%/*}"
+          source_url="https://nuget.pkg.github.com/$owner/index.json"
+          "$nuget" sources add \
+            -source "$source_url" \
+            -storepasswordincleartext \
+            -name "GitHub" \
+            -username "$owner" \
+            -password "${{ secrets.GITHUB_TOKEN }}"
+          "$nuget" setapikey "${{ secrets.GITHUB_TOKEN }}" \
+            -source "$source_url"
 
+#         For classic mode:
 #         vcpkg integrate install
 #         vcpkg install --triplet=${{ matrix.arch.msvc_triplet }} sdl2 sdl2-mixer[core,nativemidi,libmodplug,opusfile] sdl2-net libsamplerate
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # CMP0077 supress some arcane CMake warning when using vcpkg.
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-# Automatically installs direct dependencies when using vcpkg.
+# Automatically copy dependencies into the output directory for executables when using vcpkg.
+set(VCPKG_APPLOCAL_DEPS ON)
+# Automatically installs dependencies when using vcpkg.
 set(X_VCPKG_APPLOCAL_DEPS_INSTALL ON)
 Option(VCPKG_MANIFEST_MODE "Operate in vcpkg manifest mode instead of classic mode" ON)
 

--- a/lib/DLL/CMakeLists.txt
+++ b/lib/DLL/CMakeLists.txt
@@ -1,8 +1,6 @@
 if(WIN32)
     if(VCPKG_INSTALLED_DIR)
-        # vcpkg copies DLLs for direct dependencies by itself
-        # TODO manually copy transitive dependencies from vcpkg if they exist (SDL_Mixer "plugins")
-        # TODO manually add install rules for transitive dependencies from vcpkg if they exist (SDL_Mixer "plugins")
+        # vcpkg copies and installs DLLs for dependencies by itself
         return()
     endif()
 


### PR DESCRIPTION
TODOs about SDL2_mixer fixed themselves with SDL2_mixer package update in vcpkg.