### PR TITLE
Console: shorten and revamp console prints

### DIFF
--- a/lib/pcsound/pcsound.c
+++ b/lib/pcsound/pcsound.c
@@ -99,7 +99,7 @@ int PCSound_Init(pcsound_callback_func callback_func)
                 }
                 else
                 {
-                    printf("Failed to initialize PC sound driver: %s\n",
+                    printf("Failed to initialize PC sound driver: \'%s\'.\n",
                            drivers[i]->name);
                     break;
                 }
@@ -122,7 +122,7 @@ int PCSound_Init(pcsound_callback_func callback_func)
     
     if (pcsound_driver != NULL)
     {
-        printf("Using PC sound driver: %s\n", pcsound_driver->name);
+        printf("Using PC sound driver: \'%s\'.\n", pcsound_driver->name);
         return 1;
     }
     else

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -2300,8 +2300,8 @@ void D_SetGameDescription(void)
             }
         }
         printf(english_language ?
-        "    loaded %i DEHACKED lumps from PWAD files.\n" :
-        "    загружено блоков Dehacked из WAD-файлов: %i.\n", loaded);
+        "    loaded %i DEHACKED lumps from PWAD files\n" :
+        "    загружено блоков DEHACKED из WAD-файлов: %i\n", loaded);
     }
 }
 
@@ -2795,13 +2795,40 @@ void D_DoomMain (void)
 
     I_AtExit(D_Endoom, false);
 
-    if (devparm)
-    DEH_printf(english_language ? D_DEVSTR : D_DEVSTR_RUS);
+    // Load configuration files before initialising other subsystems.
+
+#ifdef _WIN32
+
+    //!
+    // @platform windows
+    // @vanilla
+    //
+    // Save configuration data and savegames in c:\doomdata,
+    // allowing play from CD.
+    //
+
+    if (M_ParmExists("-cdrom"))
+    {
+        // DEH_printf(english_language ? D_CDROM : D_CDROM_RUS);
+        M_SetConfigDir("c:\\doomdata\\");
+    }
+    else
+#endif
+    {
+        // Auto-detect the configuration dir.
+        M_SetConfigDir(NULL);
+    }
+    M_SetConfigFilename(PROGRAM_PREFIX "doom.ini");
+    D_BindVariables();
+    M_LoadConfig();
 
     DEH_printf(english_language ?
                "Z_Init: Init zone memory allocation daemon. \n" :
                "Z_Init: Инициализация распределения памяти.\n");
     Z_Init ();
+
+    M_PrintConfigDir();
+    M_PrintConfigFile();
 
 #ifdef FEATURE_MULTIPLAYER
     //!
@@ -2934,27 +2961,7 @@ void D_DoomMain (void)
 
     // find which dir to use for config files
 
-#ifdef _WIN32
 
-    //!
-    // @platform windows
-    // @vanilla
-    //
-    // Save configuration data and savegames in c:\doomdata,
-    // allowing play from CD.
-    //
-
-    if (M_ParmExists("-cdrom"))
-    {
-        DEH_printf(english_language ? D_CDROM : D_CDROM_RUS);
-        M_SetConfigDir("c:\\doomdata\\");
-    }
-    else
-#endif
-    {
-        // Auto-detect the configuration dir.
-        M_SetConfigDir(NULL);
-    }
 
     //!
     // @arg <x>
@@ -2986,14 +2993,6 @@ void D_DoomMain (void)
         sidemove[0] = sidemove[0]*scale/100;
         sidemove[1] = sidemove[1]*scale/100;
     }
-
-    // Load configuration files before initialising other subsystems.
-    DEH_printf(english_language ?
-               "M_LoadDefaults: Load system defaults.\n" :
-               "M_LoadDefaults: Загрузка системных стандартов.\n");
-    M_SetConfigFilename(PROGRAM_PREFIX "doom.ini");
-    D_BindVariables();
-    M_LoadConfig();
 
     // init subsystems
     DEH_printf(english_language ?
@@ -3457,7 +3456,7 @@ void D_DoomMain (void)
 
     DEH_printf(english_language ?
                "R_Init: Init DOOM rendering system - [" :
-               "R_Init: Инициализация системы рендеринга DOOM - [");
+               "R_Init: Инициализация рендерера DOOM - [");
     R_Init ();
     printf("]");
 

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -2300,8 +2300,8 @@ void D_SetGameDescription(void)
             }
         }
         printf(english_language ?
-        " loaded %i DEHACKED lumps from PWAD files.\n" :
-        " загружено блоков Dehacked из WAD-файлов: %i.\n", loaded);
+        "    loaded %i DEHACKED lumps from PWAD files.\n" :
+        "    загружено блоков Dehacked из WAD-файлов: %i.\n", loaded);
     }
 }
 
@@ -2314,8 +2314,8 @@ static boolean D_AddFile(char *filename)
     wad_file_t *handle;
 
     printf(english_language ?
-           " loading: %s\n" :
-           " загрузка: %s\n",
+           "    loading: %s\n" :
+           "    загрузка: %s\n",
            filename);
     handle = W_AddFile(filename);
 
@@ -2997,7 +2997,7 @@ void D_DoomMain (void)
 
     // init subsystems
     DEH_printf(english_language ?
-               "V_Init: allocate screens.\n" :
+               "V_Init: Init video.\n" :
                "V_Init: Инициализация видео.\n");
     V_Init ();
 
@@ -3456,8 +3456,8 @@ void D_DoomMain (void)
     CT_Init();
 
     DEH_printf(english_language ?
-               "R_Init: Init DOOM refresh daemon - [" :
-               "R_Init: Инициализация процесса запуска DOOM - [");
+               "R_Init: Init DOOM rendering system - [" :
+               "R_Init: Инициализация системы рендеринга DOOM - [");
     R_Init ();
     printf("]");
 

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1936,8 +1936,8 @@ void AutoloadFiles(const char* wadName)
     while((filename = I_NextGlob(glob)) != NULL)
     {
         printf(english_language ?
-               " [Autoload]" :
-               " [Автозагрузка]");
+               "    [autoload]" :
+               "    [автозагрузка]");
         LoadFile(filename, false);
     }
     I_EndGlob(glob);
@@ -2824,11 +2824,13 @@ void D_DoomMain (void)
 
     DEH_printf(english_language ?
                "Z_Init: Init zone memory allocation daemon. \n" :
-               "Z_Init: Инициализация распределения памяти.\n");
+               "Z_Init: Инициализация зональной памяти.\n");
     Z_Init ();
 
     M_PrintConfigDir();
     M_PrintConfigFile();
+
+    savegamedir = M_GetSaveGameDir();
 
 #ifdef FEATURE_MULTIPLAYER
     //!
@@ -3025,7 +3027,7 @@ void D_DoomMain (void)
     modifiedgame = false;
 
     DEH_printf(english_language ?
-               "W_Init: Init WADfiles.\n" :
+               "W_Init: Init WAD files.\n" :
                "W_Init: Инициализация WAD-файлов.\n");
     D_AddFile(iwadfile);
     numiwadlumps = numlumps;
@@ -3196,8 +3198,6 @@ void D_DoomMain (void)
     // Set the gamedescription string. This is only possible now that
     // we've finished loading Dehacked patches.
     D_SetGameDescription();
-
-    savegamedir = M_GetSaveGameDir();
 
     // Check for -file in shareware
     if (modifiedgame && (gamevariant != freedoom))
@@ -3455,7 +3455,7 @@ void D_DoomMain (void)
     CT_Init();
 
     DEH_printf(english_language ?
-               "R_Init: Init DOOM rendering system - [" :
+               "R_Init: Init DOOM render system - [" :
                "R_Init: Инициализация рендерера DOOM - [");
     R_Init ();
     printf("]");

--- a/src/doom/d_net.c
+++ b/src/doom/d_net.c
@@ -284,15 +284,53 @@ void D_CheckNetGame (void)
     D_StartNetGame(&settings, NULL);
     LoadGameSettings(&settings);
 
-    DEH_printf(english_language ?
-               " startskill %i  deathmatch: %i  startmap: %i  startepisode: %i\n" :
-               " сложность: %i  дефматч: %i  уровень: %i  эпизод: %i\n",
-               startskill, deathmatch, startmap, startepisode);
+    DEH_printf("    ");
 
-    DEH_printf(english_language ?
-               " player %i of %i (%i nodes)\n" :
-               " игроки: %i из %i (узлов: %i)\n",
-               consoleplayer+1, settings.num_players, settings.num_players);
+    if (english_language)
+    {
+        if (gamemode != commercial)
+        {
+            DEH_printf("episode: %i, ", startepisode);
+        }
+
+        DEH_printf("level: %i, ", startmap);
+
+        DEH_printf("skill: %i, mode: ", startskill+1);
+
+        DEH_printf(netgame ? "cooperative"    :
+           deathmatch == 1 ? "deathmatch"     : 
+           deathmatch == 2 ? "deathmatch 2.0" : 
+           deathmatch == 3 ? "deathmatch 3.0" : 
+                             "single player");
+                             
+    }
+    else
+    {
+        if (gamemode != commercial)
+        {
+            DEH_printf("эпизод: %i, ", startepisode);
+        }
+
+        DEH_printf("уровень: %i, ", startmap);
+
+        DEH_printf("сложность: %i, режим: ", startskill+1);
+
+        DEH_printf(netgame ? "совместная игра" :
+           deathmatch == 1 ? "дефматч"         :
+           deathmatch == 2 ? "дефматч 2.0"     :
+           deathmatch == 3 ? "дефматч 3.0"     :
+                             "одиночная игра");
+    }
+
+    DEH_printf("\n");
+
+    if (netgame)
+    {
+        DEH_printf(english_language ?
+                   "    player %i of %i (%i nodes)\n" :
+                   "    игроки: %i из %i (узлов: %i)\n",
+                   consoleplayer+1, settings.num_players, settings.num_players);
+    }
 
     // Show players here; the server might have specified a time limit
 

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1191,16 +1191,11 @@ void R_InitData (void)
     // R_GenerateComposite ivoking while level loading.
     R_InitFlats ();
     R_InitBrightmaps ();
-    printf (".");
     R_InitTextures ();
-    printf (".");
     R_InitSpriteLumps ();
-    printf (".");
     R_InitColormaps ();
-
     // [JN] Generate translucency tables
     R_InitTransMaps ();
-    printf (".");
 }
 
 // -----------------------------------------------------------------------------

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -766,13 +766,9 @@ void R_Init (void)
     }
 
     R_InitClipSegs ();
-    printf (".");
     R_InitSpritesRes ();
-    printf (".");
     R_InitPlanesRes ();
-    printf (".");
     R_InitVisplanesRes ();
-    printf (".");
     
     R_InitData ();
     printf (".");

--- a/src/gusconf.c
+++ b/src/gusconf.c
@@ -316,8 +316,8 @@ boolean GUS_WriteConfig(char *path)
     }
 
     printf(english_language ?
-           "I_SDLMusic: Using GUS patch set from:\n \t%s\n" :
-           "I_SDLMusic: Используются патчи GUS из папки:\n \t%s\n",
+           "I_SDLMusic: Using GUS patch set from:\n    %s\n" :
+           "I_SDLMusic: Используются патчи GUS из папки:\n    %s\n",
            gus_patches_path);
 
     dmxconf = ReadDMXConfig();

--- a/src/heretic/hr_main.c
+++ b/src/heretic/hr_main.c
@@ -1472,7 +1472,7 @@ void D_DoomMain(void)
     // init subsystems
     //
     DEH_printf(english_language ?
-               "V_Init: allocate screens.\n" :
+               "V_Init: Init video.\n" :
                "V_Init: Инициализация видео.\n");
     V_Init();
 
@@ -1687,10 +1687,10 @@ void D_DoomMain(void)
     CT_Init();
 
     DEH_printf(english_language ?
-               "R_Init: Init Heretic refresh daemon." :
-               "R_Init: Инициализация процесса запуска Heretic.");
+               "R_Init: Init Heretic rendering system - [" :
+               "R_Init: Инициализация системы рендеринга Heretic -[");
     R_Init();
-    DEH_printf("\n");
+    DEH_printf("]\n");
 
     DEH_printf(english_language ?
                "P_Init: Init Playloop state.\n" :

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -876,8 +876,8 @@ void D_DoomMain(void)
 
     // Show version message now, so it's visible during R_Init()
     ST_Message(english_language ?
-               "R_Init: Init Hexen rendering system - [" :
-               "R_Init: Инициализация системы рендеринга Hexen - [");
+               "R_Init: Init Hexen render system - [" :
+               "R_Init: Инициализация рендерера Hexen - [");
     R_Init();
     ST_Message("]\n");
 

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -784,7 +784,7 @@ void D_DoomMain(void)
     // Initialize subsystems
 
     ST_Message(english_language ?
-               "V_Init: allocate screens.\n" :
+               "V_Init: Init video.\n" :
                "V_Init: Инициализация видео.\n");
     V_Init();
 
@@ -878,10 +878,10 @@ void D_DoomMain(void)
 
     // Show version message now, so it's visible during R_Init()
     ST_Message(english_language ?
-               "R_Init: Init Hexen refresh daemon" :
-               "R_Init: Инициализация процесса запуска Hexen");
+               "R_Init: Init Hexen rendering system - [" :
+               "R_Init: Инициализация системы рендеринга Hexen - [");
     R_Init();
-    ST_Message("\n");
+    ST_Message("]\n");
 
     //if (M_CheckParm("-net"))
     //    ST_NetProgress();       // Console player found

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -119,7 +119,6 @@ boolean nomonsters;             // checkparm of -nomonsters
 boolean respawnparm;            // checkparm of -respawn
 boolean randomclass;            // checkparm of -randclass
 boolean ravpic;                 // checkparm of -ravpic
-boolean cdrom = false;          // true if cd-rom mode active
 boolean cmdfrag;                // true if a CMD_FRAG packet should be sent out
 int artiskip = false;           // whether shift-enter skips an artifact
 int maxzone = 0x800000;         // Maximum allocated for zone heap (8meg default)
@@ -489,8 +488,8 @@ static void D_HexenQuitMessage(void)
 static void D_AddFile(char *filename)
 {
     printf(english_language ?
-    " adding: %s\n" :
-    " добавление: %s\n", filename);
+    "    adding: %s\n" :
+    "    добавление: %s\n", filename);
 
     W_AddFile(filename);
 }
@@ -619,8 +618,8 @@ void AutoloadFiles(char* wadName)
     while((filename = I_NextGlob(glob)) != NULL)
     {
         printf(english_language ?
-               " [Autoload]" :
-               " [Автозагрузка]");
+               "    [autoload]" :
+               "    [автозагрузка]");
         LoadFile(filename, false);
     }
     I_EndGlob(glob);
@@ -739,6 +738,10 @@ void D_DoomMain(void)
     ST_Message("\n");
 #endif
 
+    // Call I_ShutdownGraphics on quit
+
+    I_AtExit(I_ShutdownGraphics, true);
+
     I_AtExit(D_HexenQuitMessage, false);
     startepisode = 1;
     autostart = false;
@@ -747,10 +750,6 @@ void D_DoomMain(void)
     gamemode = commercial;
 
     // Load defaults before initing other systems
-    ST_Message(english_language ?
-               "M_LoadDefaults: Load system defaults.\n" :
-               "M_LoadDefaults: Загрузка системных стандартов.\n");
-    D_BindVariables();
 
 #ifdef _WIN32
 
@@ -762,24 +761,31 @@ void D_DoomMain(void)
     // allowing play from CD.
     //
 
-    cdrom = M_ParmExists("-cdrom");
-#endif
-
-    if (cdrom)
+    if (M_ParmExists("-cdrom"))
     {
         M_SetConfigDir("c:\\hexndata\\");
     }
     else
+#endif
     {
+        // Auto-detect the configuration dir.
         M_SetConfigDir(NULL);
     }
 
     M_SetConfigFilename(PROGRAM_PREFIX "hexen.ini");
+    D_BindVariables();
     M_LoadConfig();
 
-    // Call I_ShutdownGraphics on quit
+    ST_Message(english_language ?
+               "Z_Init: Init zone memory allocation daemon.\n" :
+               "Z_Init: Инициализация зональной памяти.\n");
+    Z_Init();
 
-    I_AtExit(I_ShutdownGraphics, true);
+    M_PrintConfigDir();
+    M_PrintConfigFile();
+
+    // Set the directory where hub savegames are saved.
+    SavePath = M_GetSaveGameDir();
 
     // Initialize subsystems
 
@@ -790,18 +796,10 @@ void D_DoomMain(void)
 
     I_AtExit(M_SaveConfig, false);
 
-    // Set the directory where hub savegames are saved.
-    SavePath = M_GetSaveGameDir();
-
-    ST_Message(english_language ?
-               "Z_Init: Init zone memory allocation daemon.\n" :
-               "Z_Init: Инициализация распределения памяти.\n");
-    Z_Init();
-
     // haleyjd: removed WATCOMC
 
     ST_Message(english_language ?
-               "W_Init: Init WADfiles.\n" :
+               "W_Init: Init WAD files.\n" :
                "W_Init: Инициализация WAD-файлов.\n");
 
     iwadfile = D_FindIWAD(IWAD_MASK_HEXEN, &gamemission);

--- a/src/hexen/s_sound.c
+++ b/src/hexen/s_sound.c
@@ -869,6 +869,7 @@ void S_Init(void)
     I_PrecacheSounds(S_sfx, NUMSFX);
 
     // Attempt to setup CD music
+#if 0
     if (snd_musicdevice == SNDDEVICE_CD)
     {
         ST_Message("    Attempting to initialize CD Music: ");
@@ -893,6 +894,7 @@ void S_Init(void)
 
         I_CDMusPrintStartup();
     }
+#endif
 }
 
 /*

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -108,6 +108,8 @@ void RD_CreateWindowsConsole(void)
     // [JN] Head text outputs.
     ReopenConsoleHandles();
 
+    SetConsoleTitle("Console");
+
     // [JN] Set a proper codepage and mode
     SetConsoleOutputCP(CP_UTF8);
     SetConsoleCP(CP_UTF8);

--- a/src/i_sdlmusic.c
+++ b/src/i_sdlmusic.c
@@ -77,15 +77,15 @@ static boolean WriteWrapperTimidityConfig(char *write_path)
     }
 
     printf(english_language ?
-           "I_SDLMusic: Using Timidity config from:\n \t%s\n" :
-           "I_SDLMusic: Используется Timidity конфиг из файла:\n \t%s\n",
+           "I_SDLMusic: Using Timidity config from:\n    %s\n" :
+           "I_SDLMusic: Используется Timidity конфиг из файла:\n    %s\n",
            timidity_cfg_path);
 
     if(!LIB_VERSION_ATLEAST(sdl_mixer_version, 2, 5, 0) && strchr(timidity_cfg_path, ' '))
     {
         printf(english_language ?
-               "\tError: The path contains spaces, which are not supported by your SDL_mixer library. Update SDL_mixer to at least 2.5.0\n" :
-               "\tОшибка: Путь содержит пробелы, что не поддерживается вашей версией библиотеки SDL_mixer. Обновите SDL_mixer хотя бы до версии 2.5.0\n");
+               "\tError: The path contains spaces, which are not supported by your SDL_mixer library. Update SDL_mixer to at least 2.5.0.\n" :
+               "\tОшибка: Путь содержит пробелы, что не поддерживается вашей версией библиотеки SDL_mixer. Обновите SDL_mixer хотя бы до версии 2.5.0.\n");
     }
 
     fstream = fopen(write_path, "w");
@@ -93,8 +93,8 @@ static boolean WriteWrapperTimidityConfig(char *write_path)
     if(fstream == NULL)
     {
         printf(english_language ?
-               "Error: Could not write Timidity config\n" :
-               "Ошибка: Не удалось записать конфигурацию Timidity\n");
+               "Error: Could not write Timidity config.\n" :
+               "Ошибка: Не удалось записать конфигурацию Timidity.\n");
         return false;
     }
 
@@ -226,7 +226,7 @@ static boolean I_SDL_InitMusic(void)
         }
         else if (Mix_OpenAudioDevice(snd_samplerate, AUDIO_S16SYS, 2, 1024, NULL, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE) < 0)
         {
-            fprintf(stderr, "Error initializing SDL_mixer: %s\n",
+            fprintf(stderr, "Error initializing SDL_mixer: \'%s\'.\n",
                     SDL_GetError());
             SDL_QuitSubSystem(SDL_INIT_AUDIO);
         }
@@ -257,8 +257,8 @@ static boolean I_SDL_InitMusic(void)
     if (snd_musicdevice != SNDDEVICE_GUS && strlen(fluidsynth_sf_path) > 0 && strlen(timidity_cfg_path) == 0)
     {
         printf(english_language ?
-               "I_SDLMusic: Using FluidSynth soundfont from:\n \t%s\n" :
-               "I_SDLMusic: Используется FluidSynth soundfont из файла:\n \t%s\n",
+               "I_SDLMusic: Using FluidSynth soundfont from:\n    %s\n" :
+               "I_SDLMusic: Используется FluidSynth soundfont из файла:\n    %s\n",
                fluidsynth_sf_path);
 
         Mix_SetSoundFonts(fluidsynth_sf_path);
@@ -267,8 +267,8 @@ static boolean I_SDL_InitMusic(void)
     if(snd_musicdevice != SNDDEVICE_GUS && strlen(fluidsynth_sf_path) == 0 && strlen(timidity_cfg_path) == 0)
     {
         printf(english_language ?
-               "I_SDLMusic: Using SDL-defined MIDI backend\n" :
-               "I_SDLMusic: Используется определённый SDL бэкэнд MIDI\n");
+               "I_SDLMusic: Using SDL-defined MIDI backend.\n" :
+               "I_SDLMusic: Используется MIDI бэкэнд определённый SDL.\n");
     }
 
     // If snd_musiccmd is set, we need to call Mix_SetMusicCMD to
@@ -552,7 +552,9 @@ static void *I_SDL_RegisterSong(void *data, int len)
         else
         {
             music = NULL;
-            fprintf(stderr, "Error loading midi: Failed to register song.\n");
+            fprintf(stderr, english_language ?
+                    "Error loading midi: Failed to register song.\n" :
+                    "Ошибка загрузки при регистрации midi файла.\n");
         }
     }
     else
@@ -562,7 +564,9 @@ static void *I_SDL_RegisterSong(void *data, int len)
         if (music == NULL)
         {
             // Failed to load
-            fprintf(stderr, "Error loading midi: %s\n", SDL_GetError());
+            fprintf(stderr, english_language ? 
+                    "Error loading midi: \'%s\'.\n" :
+                    "Ошибка загрузки midi: \'%s\'.\n", SDL_GetError());
         }
 
         // Remove the temporary MIDI file; however, when using an external

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -156,8 +156,8 @@ byte *I_ZoneBase (int *size)
     if (!printed)
     {
         printf(english_language ?
-               "zone memory: %p, %x MB allocated for zone\n" :
-               "Распределение памяти: %p, выделено %x Мбайт.\n", 
+               "    zone memory: %p, %x MB allocated for zone\n" :
+               "    распределение памяти: %p, выделено %x Мбайт\n", 
                zonemem, *size >> 20); // [crispy] human-understandable zone heap size
     }
 

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -157,7 +157,7 @@ byte *I_ZoneBase (int *size)
     {
         printf(english_language ?
                "    zone memory: %p, %x MB allocated for zone\n" :
-               "    распределение памяти: %p, выделено %x Мбайт\n", 
+               "    зональная память: %p, выделено %x Мбайт\n", 
                zonemem, *size >> 20); // [crispy] human-understandable zone heap size
     }
 

--- a/src/i_system.c
+++ b/src/i_system.c
@@ -121,6 +121,7 @@ byte *I_ZoneBase (int *size)
     int min_ram, default_ram;
     int p;
     static int i = 1;
+    static boolean printed = false;
 
     //!
     // @arg <mb>
@@ -152,10 +153,15 @@ byte *I_ZoneBase (int *size)
     // [crispy] if called again, allocate another zone twice as big
     i *= 2;
 
-    printf(english_language ?
-           "zone memory: %p, %x MB allocated for zone\n" :
-           "Распределение памяти: %p, выделено %x Мбайт.\n", 
-           zonemem, *size >> 20); // [crispy] human-understandable zone heap size
+    if (!printed)
+    {
+        printf(english_language ?
+               "zone memory: %p, %x MB allocated for zone\n" :
+               "Распределение памяти: %p, выделено %x Мбайт.\n", 
+               zonemem, *size >> 20); // [crispy] human-understandable zone heap size
+    }
+
+    printed = true;
 
     return zonemem;
 }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -979,8 +979,8 @@ static void LoadSections(FILE *file)
                 if(handlers[i]->isHandling(sectionName))
                 {
                     printf(english_language ?
-                           "\tM_Config: Loading section \"%s\"\n" :
-                           "\tM_Config: Загрузка секции \"%s\"\n", sectionName);
+                           "M_Config: Loading section \"%s\"\n" :
+                           "M_Config: Загрузка секции \"%s\"\n", sectionName);
                     while(!feof(file))
                     {
                         if(fscanf(file, "%99[^\n =] = %299[^\n]%*1[\n]", keyName, value) != 2)
@@ -1001,7 +1001,7 @@ static void LoadSections(FILE *file)
         }
         else
         {
-            printf("\tM_Config: Error: Failed to load config\n");
+            printf("    M_Config: Error: Failed to load config\n");
             break;
         }
     }
@@ -1043,7 +1043,7 @@ void M_LoadConfig(void)
 
     printf(english_language ?
            "Loading config form %s\n" :
-           "Загрузка файла конфигурации:\n \t%s\n",
+           "Загрузка файла конфигурации:\n    %s\n",
            configPath);
 
     file = fopen(configPath, "r");
@@ -1067,7 +1067,7 @@ void M_LoadConfig(void)
     {
         if(fscanf(file, "config_version = %i\n\n", &cfg_version) != 1)
         {
-            printf("\tM_Config: Error: Unsupported config format\n");
+            printf("    M_Config: Error: Unsupported config format\n");
             ApplyDefaults();
             fclose(file);
             return;
@@ -1208,7 +1208,7 @@ void M_SetConfigDir(char *dir)
     {
         printf(english_language ?
                "Using %s for configuration\n" :
-               "Настройки программы будут расположены в папке:\n \t%s\n",
+               "Настройки программы будут расположены в папке:\n    %s\n",
                configdir);
     }
 
@@ -1260,8 +1260,8 @@ char *M_GetSaveGameDir()
         M_MakeDirectory(savegamedir);
     }
     printf(english_language ?
-            "Savegames folder:\n \t%s\n" :
-            "Сохраненные игры будут расположены в папке:\n \t%s\n",
+            "Savegames folder:\n    %s\n" :
+            "Сохраненные игры будут расположены в папке:\n    %s\n",
             savegamedir);
     return savegamedir;
 }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -978,9 +978,6 @@ static void LoadSections(FILE *file)
             {
                 if(handlers[i]->isHandling(sectionName))
                 {
-                    printf(english_language ?
-                           "M_Config: Loading section \"%s\"\n" :
-                           "M_Config: Загрузка секции \"%s\"\n", sectionName);
                     while(!feof(file))
                     {
                         if(fscanf(file, "%99[^\n =] = %299[^\n]%*1[\n]", keyName, value) != 2)
@@ -1041,11 +1038,6 @@ void M_LoadConfig(void)
         configPath = M_StringJoin(configdir, config_file_name, NULL);
     }
 
-    printf(english_language ?
-           "Loading config form %s\n" :
-           "Загрузка файла конфигурации:\n    %s\n",
-           configPath);
-
     file = fopen(configPath, "r");
     if(file == NULL)
     {
@@ -1088,6 +1080,14 @@ void M_LoadConfig(void)
     }
 
     M_ApplyMigration();
+}
+
+void M_PrintConfigFile (void)
+{
+    printf(english_language ?
+           "Loading configuration file:\n    %s\n" :
+           "Загрузка файла конфигурации:\n    %s\n",
+           configPath);
 }
 
 // Get a configuration file variable by its name
@@ -1204,17 +1204,20 @@ void M_SetConfigDir(char *dir)
         configdir = GetDefaultConfigDir();
     }
 
-    if (strcmp(configdir, "") != 0)
-    {
-        printf(english_language ?
-               "Using %s for configuration\n" :
-               "Настройки программы будут расположены в папке:\n    %s\n",
-               configdir);
-    }
-
     // Make the directory if it doesn't already exist:
 
     M_MakeDirectory(configdir);
+}
+
+void M_PrintConfigDir (void)
+{
+    if (strcmp(configdir, "") != 0)
+    {
+        printf(english_language ?
+               "Configuration directory path:\n    %s\n" :
+               "Настройки программы будут расположены в папке:\n    %s\n",
+               configdir);
+    }
 }
 
 //

--- a/src/m_config.h
+++ b/src/m_config.h
@@ -56,10 +56,12 @@ typedef enum
 } default_type_t;
 
 void M_LoadConfig(void);
+void M_PrintConfigFile(void);
 void M_SaveConfig(void);
 void M_AppendConfigSection(const char* sectionName, sectionHandler_t* handler);
 void M_SaveDefaultAlternate(char *main);
 void M_SetConfigDir(char *dir);
+void M_PrintConfigDir(void);
 void M_BindIntVariable(char *name, int *variable);
 void M_BindFloatVariable(char *name, float *variable);
 void M_BindStringVariable(char *name, char **variable);

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -348,7 +348,6 @@ const char *M_FileName(const char *path)
 void M_ExtractFileBase(char *path, char *dest)
 {
     char *src;
-    char *filename;
     int length;
 
     src = path + strlen(path) - 1;
@@ -358,8 +357,6 @@ void M_ExtractFileBase(char *path, char *dest)
     {
 	src--;
     }
-
-    filename = src;
 
     // Copy up to eight characters
     // Note: Vanilla Doom exits with an error if a filename is specified
@@ -371,15 +368,6 @@ void M_ExtractFileBase(char *path, char *dest)
 
     while (*src != '\0' && *src != '.')
     {
-        if (length >= 8)
-        {
-            printf(english_language ?
-                   "Warning: Truncated '%s' lump name to '%.8s'.\n" :
-                   "Внимание: название блока '%s' сокращено до '%.8s'.\n",
-                   filename, dest);
-            break;
-        }
-
 	dest[length++] = toupper((int)*src++);
     }
 }

--- a/src/win_launcher.c
+++ b/src/win_launcher.c
@@ -12,6 +12,13 @@
 // GNU General Public License for more details.
 //
 
+#ifdef HAVE_CONSOLE
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
 #include "SDL.h"
 #include "doomtype.h"
 
@@ -22,6 +29,10 @@ int main(int argc, char** argv)
 {
 #ifdef HAVE_CONSOLE
     console_connected = true;
+
+    // [JN] Set a proper codepage and mode
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
 #endif
     return InterDoom_Main(argc, argv);
 }


### PR DESCRIPTION
- No more mixed RU/EN strings at startup in English language.
- Slightly reordered prints/functions for better view: config stuff first, zone memory second and so on.
- "Zone memory" = "Зональная память" and etc.

Common style:
```
I_Funtion: Loaded something.
    loaded something good after four spaces
I_Pitto: Generating pitto! array - [......]
Another line, starts from capital char.
```

@Dasperal anything from your side? .com seems to have broken code page in output, here's what I got in RU language ([screenshot](https://user-images.githubusercontent.com/21193394/228317010-82a68899-12d4-44d4-bd55-6784b639f165.png)).