### PR TITLE
CI: Disable MSVC

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -51,21 +51,19 @@ jobs:
             name: "cl"
             cmake_gen: "Visual Studio 16 2019" # Visual Studio 17 2022
         exclude:
-          - # Disable x86 build on linux
+          - # Disable x86 build on linux (require crosscompiling)
             os:
               name: "Linux"
             arch:
               name: "x86"
-          - # Disable MSVC compiler on Linux
+          - # Disable MSVC compiler on Linux (no MSVC for Linux)
             os:
               name: "Linux"
             compiler:
               display_name: "MSVC"
-          - # Disable MSVC compiler for x86
+          - # Disable MSVC compiler
             compiler:
               display_name: "MSVC"
-            arch:
-              name: "x86"
         include:
           -
             shell: "bash"


### PR DESCRIPTION
It continues to fail sporadically with LNK1201.
And binary cashing is not working for JNechaevsky/inter-doom for some reason.
Did we already hit limits for GitHub Packages?