### PR TITLE
Set the recommended SDL audio driver to "directsound" (skip "wasapi")…

### DIFF
--- a/src/i_sound.c
+++ b/src/i_sound.c
@@ -28,7 +28,9 @@
 
 #include "gusconf.h"
 #include "i_sound.h"
+#include "i_system.h"
 #include "i_video.h"
+#include "jn.h"
 #include "m_argv.h"
 #include "m_config.h"
 #include "m_misc.h"
@@ -221,6 +223,15 @@ void I_InitSound(boolean use_sfx_prefix)
 
     if (!nosound && !screensaver_mode)
     {
+#ifdef _WIN32
+        // [Dasperal] Set the recommended SDL audio driver to "directsound" (skip "wasapi")
+        // on Windows Vista to avoid sound stutters.
+        if(I_CheckWindowsVista())
+        {
+            SDL_SetHintWithPriority(SDL_HINT_AUDIODRIVER, "directsound", SDL_HINT_OVERRIDE);
+        }
+#endif
+
         // This is kind of a hack. If native MIDI is enabled, set up
         // the TIMIDITY_CFG environment variable here before SDL_mixer
         // is opened.
@@ -241,6 +252,10 @@ void I_InitSound(boolean use_sfx_prefix)
         {
             InitMusicModule();
         }
+        printf(english_language ?
+               "I_InitSound: SDL audio driver - %s\n" :
+               "I_InitSound: Аудио драйвер SDL - %s\n",
+            SDL_GetCurrentAudioDriver());
     }
 }
 

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -73,6 +73,8 @@ void I_ConsolePause(void);
 
 #define CONSOLE_PROLOG RD_CreateWindowsConsole();
 #define CONSOLE_EPILOG if(!console_connected) I_ConsolePause();
+
+int I_CheckWindowsVista(void);
 #else
 #define CONSOLE_PROLOG
 #define CONSOLE_EPILOG

--- a/src/win_compat.c
+++ b/src/win_compat.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 
 #include "SDL_syswm.h"
+#include "i_system.h"
 
 wchar_t* ConvertToUtf8(const char *str)
 {
@@ -181,6 +182,32 @@ int D_mkdir(const char *dirname)
 }
 
 typedef long (__stdcall *PRTLGETVERSION)(PRTL_OSVERSIONINFOEXW);
+
+int I_CheckWindowsVista(void)
+{
+    PRTLGETVERSION  pRtlGetVersion = (PRTLGETVERSION) GetProcAddress(GetModuleHandle("ntdll.dll"), "RtlGetVersion");
+
+    if(pRtlGetVersion)
+    {
+        OSVERSIONINFOEXW info;
+
+        memset(&info, 0, sizeof(OSVERSIONINFOEXW));
+        info.dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOEXW);
+
+        pRtlGetVersion((PRTL_OSVERSIONINFOEXW)&info);
+
+        if(info.dwPlatformId == VER_PLATFORM_WIN32_NT)
+        {
+            if(info.dwMajorVersion == 6)
+            {
+                if(info.dwMinorVersion == 0)
+                    return 1;
+            }
+        }
+    }
+
+    return 0;
+}
 
 int I_CheckWindows11(void)
 {


### PR DESCRIPTION
… on Windows Vista to avoid sound stutters.

Fixes #439