### PR TITLE
H&H: Properly save and load `special1` and `special2` fields containing pointers

### DIFF
--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -733,8 +733,10 @@ static void StreamInMobjSpecials(mobj_t *mobj)
         case MT_DRAGON:
         case MT_THRUSTFLOOR_UP:
         case MT_THRUSTFLOOR_DOWN:
+        case MT_SUMMON_FX:
         case MT_MINOTAUR:
         case MT_SORCFX1:
+        case MT_MSTAFF_FX2:
         case MT_KORAX_SPIRIT1:
         case MT_KORAX_SPIRIT2:
         case MT_KORAX_SPIRIT3:
@@ -924,6 +926,7 @@ static void StreamOutMobjSpecials(mobj_t *mobj)
         case MT_DRAGON:
         case MT_THRUSTFLOOR_UP:
         case MT_THRUSTFLOOR_DOWN:
+        case MT_SUMMON_FX:
         case MT_MINOTAUR:
         case MT_SORCFX1:
         case MT_MSTAFF_FX2:

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -735,6 +735,12 @@ static void StreamInMobjSpecials(mobj_t *mobj)
         case MT_THRUSTFLOOR_DOWN:
         case MT_MINOTAUR:
         case MT_SORCFX1:
+        case MT_KORAX_SPIRIT1:
+        case MT_KORAX_SPIRIT2:
+        case MT_KORAX_SPIRIT3:
+        case MT_KORAX_SPIRIT4:
+        case MT_KORAX_SPIRIT5:
+        case MT_KORAX_SPIRIT6:
             SetMobjPtr(&mobj->special1.m, special1);
             break;
 
@@ -921,6 +927,12 @@ static void StreamOutMobjSpecials(mobj_t *mobj)
         case MT_MINOTAUR:
         case MT_SORCFX1:
         case MT_MSTAFF_FX2:
+        case MT_KORAX_SPIRIT1:
+        case MT_KORAX_SPIRIT2:
+        case MT_KORAX_SPIRIT3:
+        case MT_KORAX_SPIRIT4:
+        case MT_KORAX_SPIRIT5:
+        case MT_KORAX_SPIRIT6:
             if (corpse)
             {
                 special1 = MOBJ_NULL;


### PR DESCRIPTION
Convert mobjs pointers in `special1` and `special2` fields to indexes on saving and restore them on loading.
Fixes potential crushes when loading savegame.

Savegames from previous versions may become incompatible.
Breaks compatibility with DOS savegame if it still existed.