### PR TITLE
Fix `bk_show_message_list` for netgame chat

### DIFF
--- a/src/doom/ct_chat.c
+++ b/src/doom/ct_chat.c
@@ -158,7 +158,7 @@ boolean CT_Responder (event_t *ev)
     int   sendto;
     const char *macro;
 
-    if(BK_isKeyDown(ev, bk_show_message_list))
+    if(BK_isKeyDown(ev, bk_show_message_list) && !chatmodeon)
     {
         // TODO Show last N messages
         players[consoleplayer].messageTics = messages_timeout * TICRATE;

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1057,7 +1057,7 @@ static MenuItem_t Bindings4Items[] = {
     I_EFUNC("Pause",                 "gfepf",                        BK_StartBindingKey, bk_pause),             // Пауза
     I_EFUNC("Finish demo recording", "pfrjyxbnm pfgbcm ltvj",        BK_StartBindingKey, bk_finish_demo),       // Закончить запись демо
     I_EFUNC("Demo fast-forward",     ",scnhfz gthtvjnrf ltvj",       BK_StartBindingKey, bk_demo_speed),        // Быстрая перемотка демо
-    I_EFUNC("Sow last message",      "Gjcktlytt cjj,otybt",          BK_StartBindingKey, bk_show_message_list), // Последнее сообщение
+    I_EFUNC("Show last message",     "Gjcktlytt cjj,otybt",          BK_StartBindingKey, bk_show_message_list), // Последнее сообщение
     I_TITLE("Toggleables",           "gthtrk.xtybt"),
     I_EFUNC("Mouse look",            "j,pjh vsim.",                  BK_StartBindingKey, bk_toggle_mlook),      // Обзор мышью
     I_EFUNC("Always run",            "gjcnjzyysq ,tu",               BK_StartBindingKey, bk_toggle_autorun),    // Постоянный бег

--- a/src/heretic/ct_chat.c
+++ b/src/heretic/ct_chat.c
@@ -147,7 +147,7 @@ static const boolean ValidChatChar (const char c)
 
 const boolean CT_Responder (event_t *ev)
 {
-    if(BK_isKeyDown(ev, bk_show_message_list))
+    if(BK_isKeyDown(ev, bk_show_message_list) && !chatmodeon)
     {
         // TODO Show last N messages
         players[consoleplayer].messageTics = messages_timeout * TICRATE;

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -980,7 +980,7 @@ static MenuItem_t Bindings5Items[] = {
     I_EFUNC("Pause",                 "gfepf",                 BK_StartBindingKey, bk_pause),             // Пауза
     I_EFUNC("FINISH DEMO RECORDING", "PFRJYXBNM PFGBCM LTVJ", BK_StartBindingKey, bk_finish_demo),       // Закончить запись демо
     I_EFUNC("DEMO FAST-FORWARD",     ",SCNHFZ GTHTVJNRF LTVJ",BK_StartBindingKey, bk_demo_speed),        // Быстрая перемотка демо
-    I_EFUNC("Sow last message",      "Gjcktlytt cjj,otybt",   BK_StartBindingKey, bk_show_message_list), // Последнее сообщение
+    I_EFUNC("Show last message",     "Gjcktlytt cjj,otybt",   BK_StartBindingKey, bk_show_message_list), // Последнее сообщение
     I_TITLE("INVENTORY",             "BYDTYNFHM"),
     I_EFUNC("NEXT ITEM",             "CKTLE.OBQ GHTLVTN",     BK_StartBindingKey, bk_inv_right),
     I_EFUNC("PREVIOUS ITEM",         "GHTLSLEOBQ GHTLVTN",    BK_StartBindingKey, bk_inv_left),

--- a/src/hexen/ct_chat.c
+++ b/src/hexen/ct_chat.c
@@ -171,7 +171,7 @@ boolean CT_Responder(event_t * ev)
 
     int sendto;
 
-    if(BK_isKeyDown(ev, bk_show_message_list))
+    if(BK_isKeyDown(ev, bk_show_message_list) && !chatmodeon)
     {
         // TODO Show last N messages
         players[consoleplayer].messageTics = messages_timeout * TICRATE;

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -974,7 +974,7 @@ static MenuItem_t Bindings4Items[] = {
     I_EFUNC("SAVE A SCREENSHOT",     "CRHBYIJN",              BK_StartBindingKey, bk_screenshot),        // Скриншот
     I_EFUNC("Pause",                 "gfepf",                 BK_StartBindingKey, bk_pause),             // Пауза
     I_EFUNC("FINISH DEMO RECORDING", "PFRJYXBNM PFGBCM LTVJ", BK_StartBindingKey, bk_finish_demo),       // Закончить запись демо
-    I_EFUNC("Sow last message",      "Gjcktlytt cjj,otybt",   BK_StartBindingKey, bk_show_message_list), // Последнее сообщение
+    I_EFUNC("Show last message",     "Gjcktlytt cjj,otybt",   BK_StartBindingKey, bk_show_message_list), // Последнее сообщение
     I_TITLE("TOGGLEABLES",           "GTHTRK.XTYBT"),
     I_EFUNC("MOUSE LOOK",            "J,PJH VSIM.",           BK_StartBindingKey, bk_toggle_mlook),      // Обзор мышью
     I_EFUNC("ALWAYS RUN",            "GJCNJZYYSQ ,TU",        BK_StartBindingKey, bk_toggle_autorun),    // Постоянный бег


### PR DESCRIPTION
@Dasperal, без `&& !chatmodeon)` пропадает возможность отправить сообщение в чат. Enter просто показывает последнее сообщение предотвращая отправку, и из режима чата выйти уже не получается.

Чат проще всего тестировать через запуск реальной сетевой игры на одном компьютере:

- inter-doom.exe -privateserver
- inter-doom.exe -autojoin