### PR TITLE
Heretic & Hexen: Fix bug with "Mute inactive window" option

### DIFF
--- a/src/heretic/s_sound.c
+++ b/src/heretic/s_sound.c
@@ -817,9 +817,14 @@ void S_SetMaxVolume(boolean fullprocess)
     }
 }
 
-static boolean musicPaused;
+static boolean musicPaused = false;
+static boolean sound_muted = false;
 void S_SetMusicVolume(void)
 {
+    if(sound_muted)
+    {
+        return;
+    }
     I_SetMusicVolume(snd_MusicVolume);
     if (snd_MusicVolume == 0)
     {
@@ -862,6 +867,7 @@ void S_MuteSound(void)
     }
 
     volume_needs_update = false;
+    sound_muted = true;
 }
 
 // -----------------------------------------------------------------------------
@@ -877,4 +883,5 @@ void S_UnMuteSound(void)
     S_SetMaxVolume(true);
 
     volume_needs_update = false;
+    sound_muted = false;
 }

--- a/src/hexen/s_sound.c
+++ b/src/hexen/s_sound.c
@@ -202,7 +202,7 @@ void S_StartSong(int song, boolean loop)
 
         RegisteredSong = I_RegisterSong(Mus_SndPtr, length);
         // [JN] Set proper music volume.
-        I_SetMusicVolume(snd_MusicVolume);
+        S_SetMusicVolume();
         I_PlaySong(RegisteredSong, loop);
         Mus_Song = song;
 
@@ -1020,8 +1020,13 @@ boolean S_GetSoundPlayingInfo(mobj_t * mobj, int sound_id)
 //
 //==========================================================================
 
+static boolean sound_muted = false;
 void S_SetMusicVolume(void)
 {
+    if(sound_muted)
+    {
+        return;
+    }
     if (cdmusic)
     {
         I_CDMusSetVolume(snd_MusicVolume * 16); // 0-255
@@ -1077,6 +1082,7 @@ void S_MuteSound(void)
     S_StopAllSound();
 
     volume_needs_update = false;
+    sound_muted = true;
 }
 
 // -----------------------------------------------------------------------------
@@ -1091,6 +1097,7 @@ void S_UnMuteSound(void)
     snd_MaxVolume = snd_MaxVolume_tmp;
 
     volume_needs_update = false;
+    sound_muted = false;
 }
 
 //==========================================================================


### PR DESCRIPTION
Fixes #452 

The music change was restoring the music volume for the inactive window even if "Mute inactive window" option was enabled